### PR TITLE
Don't panic on invalid number

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -212,4 +212,13 @@ mod tests {
             _ => unreachable!(),
         };
     }
+
+    #[test]
+    fn invalid_number() {
+        if let Err(msg) = Wkt::from_str("POINT (10 20.1A)") {
+            assert_eq!("Expected a number for the Y coordinate", msg);
+        } else {
+            panic!("Should not have parsed");
+        }
+    }
 }

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -70,7 +70,7 @@ impl<'a> Iterator for Tokens<'a> {
                 let mut number = c.to_string() + &self.read_until_whitespace().unwrap_or_default();
                 match number.trim_left_matches('+').parse::<f64>() {
                     Ok(parsed_num) => Some(Token::Number(parsed_num)),
-                    Err(e) => panic!("Could not parse number: {}", e),
+                    Err(_) => None
                 }
             }
             c => {
@@ -138,6 +138,13 @@ fn test_tokenizer_1number_plus() {
     let test_str = "+4.2";
     let tokens: Vec<Token> = Tokens::from_str(test_str).collect();
     assert_eq!(tokens, vec![Token::Number(4.2)]);
+}
+
+#[test]
+fn test_tokenizer_invalid_number() {
+    let test_str = "4.2p";
+    let tokens: Vec<Token> = Tokens::from_str(test_str).collect();
+    assert_eq!(tokens, vec![]);
 }
 
 #[test]


### PR DESCRIPTION
In Wkt::from_str, invalid numbers are causing a panic but other kinds of input return an Err.

