### PR TITLE
upgrade geo_types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wkt"
 description = "Rust read/write support for well-known text (WKT)"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Corey Farwell <coreyf@rwell.org>", "Antoine Desbordes <antoine.desbordes@gmail.com>"]
 license = "MIT/Apache-2.0"
 repository = "https://github.com/georust/wkt"
@@ -10,7 +10,7 @@ readme = "README.md"
 keywords = ["geo", "geospatial", "wkt"]
 
 [dependencies]
-geo-types = {version = "0.3", optional = true}
+geo-types = {version = "0.4", optional = true}
 
 [dev-dependencies]
 criterion = { version = "0.2" }

--- a/src/towkt.rs
+++ b/src/towkt.rs
@@ -68,10 +68,8 @@ fn g_lines_to_w_lines(g_lines: &[geo_types::LineString<f64>]) -> Vec<LineString>
 }
 
 fn g_polygon_to_w_polygon(g_polygon: &geo_types::Polygon<f64>) -> Polygon {
-    let &geo_types::Polygon {
-        exterior: ref outer_line,
-        interiors: ref inner_lines,
-    } = g_polygon;
+    let outer_line = g_polygon.exterior();
+    let inner_lines = g_polygon.interiors();
     let mut poly_lines = vec![];
 
     // Outer


### PR DESCRIPTION
update to geo_types 0.4

It might be worth waiting if a new version is pushed after [this merge](https://github.com/georust/geo/pull/347), but anyway I think it'll be a patch version change.