### PR TITLE
Use generic type for precision in conversion

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ keywords = ["geo", "geospatial", "wkt"]
 
 [dependencies]
 geo-types = {version = "0.4", optional = true}
+num-traits = "0.2"
 
 [dev-dependencies]
 criterion = { version = "0.2" }

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -34,7 +34,7 @@ impl fmt::Display for Error {
     }
 }
 
-fn create_geo_coordinate<T>(coord: &Coord) -> geo_types::Coordinate<T>
+fn create_geo_coordinate<T>(coord: &Coord<T>) -> geo_types::Coordinate<T>
 where
     T: num_traits::Float,
 {
@@ -44,21 +44,20 @@ where
     }
 }
 
-fn try_into_point<T>(point: &Point) -> Result<geo_types::Geometry<T>, Error>
+fn try_into_point<T>(point: &Point<T>) -> Result<geo_types::Geometry<T>, Error>
 where
     T: num_traits::Float,
 {
     match point.0 {
         Some(ref c) => {
-            let geo_point: geo_types::Point<T> =
-                (T::from(c.x).unwrap(), T::from(c.y).unwrap()).into();
+            let geo_point: geo_types::Point<T> = (c.x, c.y).into();
             Ok(geo_point.into())
         }
         None => Err(Error::PointConversionError),
     }
 }
 
-pub fn try_into_geometry<T>(geometry: &Geometry) -> Result<geo_types::Geometry<T>, Error>
+pub fn try_into_geometry<T>(geometry: &Geometry<T>) -> Result<geo_types::Geometry<T>, Error>
 where
     T: num_traits::Float,
 {
@@ -75,7 +74,7 @@ where
     }
 }
 
-impl<'a, T> Into<geo_types::Geometry<T>> for &'a LineString
+impl<'a, T> Into<geo_types::Geometry<T>> for &'a LineString<T>
 where
     T: num_traits::Float,
 {
@@ -87,7 +86,7 @@ where
     }
 }
 
-impl<'a, T> Into<geo_types::Geometry<T>> for &'a MultiLineString
+impl<'a, T> Into<geo_types::Geometry<T>> for &'a MultiLineString<T>
 where
     T: num_traits::Float,
 {
@@ -102,7 +101,7 @@ where
     }
 }
 
-fn w_polygon_to_g_polygon<T>(polygon: &Polygon) -> geo_types::Polygon<T>
+fn w_polygon_to_g_polygon<T>(polygon: &Polygon<T>) -> geo_types::Polygon<T>
 where
     T: num_traits::Float,
 {
@@ -116,7 +115,7 @@ where
     }
 }
 
-impl<'a, T> Into<geo_types::Geometry<T>> for &'a Polygon
+impl<'a, T> Into<geo_types::Geometry<T>> for &'a Polygon<T>
 where
     T: num_traits::Float,
 {
@@ -125,7 +124,7 @@ where
     }
 }
 
-impl<'a, T> Into<geo_types::Geometry<T>> for &'a MultiPoint
+impl<'a, T> Into<geo_types::Geometry<T>> for &'a MultiPoint<T>
 where
     T: num_traits::Float,
 {
@@ -141,7 +140,7 @@ where
     }
 }
 
-impl<'a, T> Into<geo_types::Geometry<T>> for &'a MultiPolygon
+impl<'a, T> Into<geo_types::Geometry<T>> for &'a MultiPolygon<T>
 where
     T: num_traits::Float,
 {
@@ -157,7 +156,7 @@ where
 }
 
 pub fn try_into_geometry_collection<T>(
-    geometrycollection: &GeometryCollection,
+    geometrycollection: &GeometryCollection<T>,
 ) -> Result<geo_types::Geometry<T>, Error>
 where
     T: num_traits::Float,

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 extern crate geo_types;
+extern crate num_traits;
 
 use std::fmt;
 use types::*;
@@ -33,17 +34,34 @@ impl fmt::Display for Error {
     }
 }
 
-fn try_into_point(point: &Point) -> Result<geo_types::Geometry<f64>, Error> {
+fn create_geo_coordinate<T>(coord: &Coord) -> geo_types::Coordinate<T>
+where
+    T: num_traits::Float,
+{
+    geo_types::Coordinate {
+        x: T::from(coord.x).unwrap(),
+        y: T::from(coord.y).unwrap(),
+    }
+}
+
+fn try_into_point<T>(point: &Point) -> Result<geo_types::Geometry<T>, Error>
+where
+    T: num_traits::Float,
+{
     match point.0 {
         Some(ref c) => {
-            let geo_point: geo_types::Point<f64> = (c.x, c.y).into();
+            let geo_point: geo_types::Point<T> =
+                (T::from(c.x).unwrap(), T::from(c.y).unwrap()).into();
             Ok(geo_point.into())
         }
         None => Err(Error::PointConversionError),
     }
 }
 
-pub fn try_into_geometry(geometry: &Geometry) -> Result<geo_types::Geometry<f64>, Error> {
+pub fn try_into_geometry<T>(geometry: &Geometry) -> Result<geo_types::Geometry<T>, Error>
+where
+    T: num_traits::Float,
+{
     match geometry {
         Geometry::Point(point) => try_into_point(point),
         Geometry::LineString(linestring) => Ok(linestring.into()),
@@ -57,32 +75,40 @@ pub fn try_into_geometry(geometry: &Geometry) -> Result<geo_types::Geometry<f64>
     }
 }
 
-impl<'a> From<&'a LineString> for geo_types::Geometry<f64> {
-    fn from(linestring: &LineString) -> Self {
-        let geo_linestring: geo_types::LineString<f64> =
-            linestring.0.iter().map(|c| (c.x, c.y)).collect();
+impl<'a, T> Into<geo_types::Geometry<T>> for &'a LineString
+where
+    T: num_traits::Float,
+{
+    fn into(self) -> geo_types::Geometry<T> {
+        let geo_linestring: geo_types::LineString<T> =
+            self.0.iter().map(|c| create_geo_coordinate(&c)).collect();
 
         geo_linestring.into()
     }
 }
 
-impl<'a> From<&'a MultiLineString> for geo_types::Geometry<f64> {
-    fn from(multilinestring: &MultiLineString) -> Self {
-        let geo_multilinestring: geo_types::MultiLineString<f64> = multilinestring
+impl<'a, T> Into<geo_types::Geometry<T>> for &'a MultiLineString
+where
+    T: num_traits::Float,
+{
+    fn into(self) -> geo_types::Geometry<T> {
+        let geo_multilinestring: geo_types::MultiLineString<T> = self
             .0
             .iter()
-            .map(|l| l.0.iter().map(|c| (c.x, c.y)).collect::<Vec<_>>())
+            .map(|l| l.0.iter().map(|c| create_geo_coordinate(&c)).collect::<Vec<_>>())
             .collect();
 
         geo_multilinestring.into()
     }
 }
 
-fn w_polygon_to_g_polygon(polygon: &Polygon) -> geo_types::Polygon<f64> {
+fn w_polygon_to_g_polygon<T>(polygon: &Polygon) -> geo_types::Polygon<T>
+where
+    T: num_traits::Float,
+{
     let mut iter = polygon
         .0
-        .iter()
-        .map(|l| l.0.iter().map(|c| (c.x, c.y)).collect::<Vec<_>>().into());
+        .iter().map(|l| l.0.iter().map(|c| create_geo_coordinate(c)).collect::<Vec<_>>().into());
 
     match iter.next() {
         Some(interior) => geo_types::Polygon::new(interior, iter.collect()),
@@ -90,28 +116,37 @@ fn w_polygon_to_g_polygon(polygon: &Polygon) -> geo_types::Polygon<f64> {
     }
 }
 
-impl<'a> From<&'a Polygon> for geo_types::Geometry<f64> {
-    fn from(polygon: &Polygon) -> Self {
-        w_polygon_to_g_polygon(polygon).into()
+impl<'a, T> Into<geo_types::Geometry<T>> for &'a Polygon
+where
+    T: num_traits::Float,
+{
+    fn into(self) -> geo_types::Geometry<T> {
+        w_polygon_to_g_polygon(self).into()
     }
 }
 
-impl<'a> From<&'a MultiPoint> for geo_types::Geometry<f64> {
-    fn from(multipoint: &MultiPoint) -> Self {
-        let geo_multipoint: geo_types::MultiPoint<f64> = multipoint
+impl<'a, T> Into<geo_types::Geometry<T>> for &'a MultiPoint
+where
+    T: num_traits::Float,
+{
+    fn into(self) -> geo_types::Geometry<T> {
+        let geo_multipoint: geo_types::MultiPoint<T> = self
             .0
             .iter()
             .filter_map(|p| p.0.as_ref())
-            .map(|c| (c.x, c.y))
+            .map(|c| create_geo_coordinate(c))
             .collect();
 
         geo_multipoint.into()
     }
 }
 
-impl<'a> From<&'a MultiPolygon> for geo_types::Geometry<f64> {
-    fn from(multipolygon: &MultiPolygon) -> Self {
-        let geo_multipolygon: geo_types::MultiPolygon<f64> = multipolygon
+impl<'a, T> Into<geo_types::Geometry<T>> for &'a MultiPolygon
+where
+    T: num_traits::Float,
+{
+    fn into(self) -> geo_types::Geometry<T> {
+        let geo_multipolygon: geo_types::MultiPolygon<T> = self
             .0
             .iter()
             .map(|p| w_polygon_to_g_polygon(p))
@@ -121,10 +156,13 @@ impl<'a> From<&'a MultiPolygon> for geo_types::Geometry<f64> {
     }
 }
 
-pub fn try_into_geometry_collection(
+pub fn try_into_geometry_collection<T>(
     geometrycollection: &GeometryCollection,
-) -> Result<geo_types::Geometry<f64>, Error> {
-    let geo_geometrycollection: geo_types::GeometryCollection<f64> = geometrycollection
+) -> Result<geo_types::Geometry<T>, Error>
+where
+    T: num_traits::Float,
+{
+    let geo_geometrycollection: geo_types::GeometryCollection<T> = geometrycollection
         .0
         .iter()
         .map(|g| try_into_geometry(g))
@@ -142,7 +180,8 @@ mod tests {
     #[test]
     fn convert_empty_point() {
         let point = Point(None).as_item();
-        assert!(try_into_geometry(&point).is_err());
+        let res: Result<geo_types::Geometry<f64>, Error> = try_into_geometry(&point);
+        assert!(res.is_err());
     }
 
     #[test]

--- a/src/towkt.rs
+++ b/src/towkt.rs
@@ -1,4 +1,5 @@
 extern crate geo_types;
+extern crate num_traits;
 
 use types::Coord;
 use types::GeometryCollection;
@@ -12,12 +13,18 @@ use Geometry;
 use Wkt;
 
 /// A trait for converting values to WKT
-pub trait ToWkt {
+pub trait ToWkt<T>
+where
+    T: num_traits::Float
+{
     /// Converts the value of `self` to an instance of WKT
-    fn to_wkt(&self) -> Wkt;
+    fn to_wkt(&self) -> Wkt<T>;
 }
 
-fn g_point_to_w_coord(g_point: &geo_types::Coordinate<f64>) -> Coord {
+fn g_point_to_w_coord<T>(g_point: &geo_types::Coordinate<T>) -> Coord<T>
+where
+    T: num_traits::Float
+{
     Coord {
         x: g_point.x,
         y: g_point.y,
@@ -26,16 +33,25 @@ fn g_point_to_w_coord(g_point: &geo_types::Coordinate<f64>) -> Coord {
     }
 }
 
-fn g_point_to_w_point(g_point: &geo_types::Point<f64>) -> Point {
+fn g_point_to_w_point<T>(g_point: &geo_types::Point<T>) -> Point<T>
+where
+    T: num_traits::Float
+{
     let coord = g_point_to_w_coord(&g_point.0);
     Point(Some(coord))
 }
 
-fn g_points_to_w_coords(g_points: &[geo_types::Coordinate<f64>]) -> Vec<Coord> {
+fn g_points_to_w_coords<T>(g_points: &[geo_types::Coordinate<T>]) -> Vec<Coord<T>>
+where
+    T: num_traits::Float
+{
     g_points.iter().map(g_point_to_w_coord).collect()
 }
 
-fn g_points_to_w_points(g_points: &[geo_types::Point<f64>]) -> Vec<Point> {
+fn g_points_to_w_points<T>(g_points: &[geo_types::Point<T>]) -> Vec<Point<T>>
+where
+    T: num_traits::Float
+{
     g_points
     .iter()
     .map(|p|&p.0)
@@ -44,21 +60,33 @@ fn g_points_to_w_points(g_points: &[geo_types::Point<f64>]) -> Vec<Point> {
     .collect()
 }
 
-fn g_line_to_w_linestring(g_line: &geo_types::Line<f64>) -> LineString {
+fn g_line_to_w_linestring<T>(g_line: &geo_types::Line<T>) -> LineString<T>
+where
+    T: num_traits::Float
+{
     g_points_to_w_linestring(&vec![g_line.start, g_line.end])
 }
 
-fn g_linestring_to_w_linestring(g_linestring: &geo_types::LineString<f64>) -> LineString {
+fn g_linestring_to_w_linestring<T>(g_linestring: &geo_types::LineString<T>) -> LineString<T>
+where
+    T: num_traits::Float
+{
     let &geo_types::LineString(ref g_points) = g_linestring;
     g_points_to_w_linestring(g_points)
 }
 
-fn g_points_to_w_linestring(g_coords: &[geo_types::Coordinate<f64>]) -> LineString {
+fn g_points_to_w_linestring<T>(g_coords: &[geo_types::Coordinate<T>]) -> LineString<T>
+where
+    T: num_traits::Float
+{
     let w_coords = g_points_to_w_coords(g_coords);
     LineString(w_coords)
 }
 
-fn g_lines_to_w_lines(g_lines: &[geo_types::LineString<f64>]) -> Vec<LineString> {
+fn g_lines_to_w_lines<T>(g_lines: &[geo_types::LineString<T>]) -> Vec<LineString<T>>
+where
+    T: num_traits::Float
+{
     let mut w_lines = vec![];
     for g_line in g_lines {
         let &geo_types::LineString(ref g_points) = g_line;
@@ -67,7 +95,10 @@ fn g_lines_to_w_lines(g_lines: &[geo_types::LineString<f64>]) -> Vec<LineString>
     w_lines
 }
 
-fn g_polygon_to_w_polygon(g_polygon: &geo_types::Polygon<f64>) -> Polygon {
+fn g_polygon_to_w_polygon<T>(g_polygon: &geo_types::Polygon<T>) -> Polygon<T>
+where
+    T: num_traits::Float
+{
     let outer_line = g_polygon.exterior();
     let inner_lines = g_polygon.interiors();
     let mut poly_lines = vec![];
@@ -85,19 +116,28 @@ fn g_polygon_to_w_polygon(g_polygon: &geo_types::Polygon<f64>) -> Polygon {
     Polygon(poly_lines)
 }
 
-fn g_mpoint_to_w_mpoint(g_mpoint: &geo_types::MultiPoint<f64>) -> MultiPoint {
+fn g_mpoint_to_w_mpoint<T>(g_mpoint: &geo_types::MultiPoint<T>) -> MultiPoint<T>
+where
+    T: num_traits::Float
+{
     let &geo_types::MultiPoint(ref g_points) = g_mpoint;
     let w_points = g_points_to_w_points(g_points);
     MultiPoint(w_points)
 }
 
-fn g_mline_to_w_mline(g_mline: &geo_types::MultiLineString<f64>) -> MultiLineString {
+fn g_mline_to_w_mline<T>(g_mline: &geo_types::MultiLineString<T>) -> MultiLineString<T>
+where
+    T: num_traits::Float
+{
     let &geo_types::MultiLineString(ref g_lines) = g_mline;
     let w_lines = g_lines_to_w_lines(g_lines);
     MultiLineString(w_lines)
 }
 
-fn g_polygons_to_w_polygons(g_polygons: &[geo_types::Polygon<f64>]) -> Vec<Polygon> {
+fn g_polygons_to_w_polygons<T>(g_polygons: &[geo_types::Polygon<T>]) -> Vec<Polygon<T>>
+where
+    T: num_traits::Float
+{
     let mut w_polygons = vec![];
     for g_polygon in g_polygons {
         w_polygons.push(g_polygon_to_w_polygon(g_polygon));
@@ -105,13 +145,19 @@ fn g_polygons_to_w_polygons(g_polygons: &[geo_types::Polygon<f64>]) -> Vec<Polyg
     w_polygons
 }
 
-fn g_mpolygon_to_w_mpolygon(g_mpolygon: &geo_types::MultiPolygon<f64>) -> MultiPolygon {
+fn g_mpolygon_to_w_mpolygon<T>(g_mpolygon: &geo_types::MultiPolygon<T>) -> MultiPolygon<T>
+where
+    T: num_traits::Float
+{
     let &geo_types::MultiPolygon(ref g_polygons) = g_mpolygon;
     let w_polygons = g_polygons_to_w_polygons(g_polygons);
     MultiPolygon(w_polygons)
 }
 
-fn g_geocol_to_w_geocol(g_geocol: &geo_types::GeometryCollection<f64>) -> GeometryCollection {
+fn g_geocol_to_w_geocol<T>(g_geocol: &geo_types::GeometryCollection<T>) -> GeometryCollection<T>
+where
+    T: num_traits::Float
+{
     let &geo_types::GeometryCollection(ref g_geoms) = g_geocol;
     let mut w_geoms = vec![];
     for g_geom in g_geoms {
@@ -121,7 +167,10 @@ fn g_geocol_to_w_geocol(g_geocol: &geo_types::GeometryCollection<f64>) -> Geomet
     GeometryCollection(w_geoms)
 }
 
-fn g_geom_to_w_geom(g_geom: &geo_types::Geometry<f64>) -> Geometry {
+fn g_geom_to_w_geom<T>(g_geom: &geo_types::Geometry<T>) -> Geometry<T>
+where
+    T: num_traits::Float
+{
     match g_geom {
         &geo_types::Geometry::Point(ref g_point) => g_point_to_w_point(g_point).as_item(),
 
@@ -147,8 +196,11 @@ fn g_geom_to_w_geom(g_geom: &geo_types::Geometry<f64>) -> Geometry {
     }
 }
 
-impl ToWkt for geo_types::Geometry<f64> {
-    fn to_wkt(&self) -> Wkt {
+impl<T> ToWkt<T> for geo_types::Geometry<T>
+where
+    T: num_traits::Float
+{
+    fn to_wkt(&self) -> Wkt<T> {
         let w_geom = g_geom_to_w_geom(&self);
         Wkt {
             items: vec![w_geom],

--- a/src/types/coord.rs
+++ b/src/types/coord.rs
@@ -12,19 +12,28 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+extern crate num_traits;
+
 use std::fmt;
+use std::str::FromStr;
 use tokenizer::{PeekableTokens, Token};
 use FromTokens;
 
 #[derive(Default)]
-pub struct Coord {
-    pub x: f64,
-    pub y: f64,
-    pub z: Option<f64>,
-    pub m: Option<f64>,
+pub struct Coord<T>
+where
+    T: num_traits::Float
+{
+    pub x: T,
+    pub y: T,
+    pub z: Option<T>,
+    pub m: Option<T>,
 }
 
-impl fmt::Display for Coord {
+impl<T> fmt::Display for Coord<T>
+where
+    T: num_traits::Float + fmt::Display
+{
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         write!(f, "{} {}", self.x, self.y)?;
         if let Some(z) = self.z {
@@ -37,8 +46,11 @@ impl fmt::Display for Coord {
     }
 }
 
-impl FromTokens for Coord {
-    fn from_tokens(tokens: &mut PeekableTokens) -> Result<Self, &'static str> {
+impl<T> FromTokens<T> for Coord<T>
+where
+    T: num_traits::Float + FromStr + Default
+{
+    fn from_tokens(tokens: &mut PeekableTokens<T>) -> Result<Self, &'static str> {
         let x = match tokens.next() {
             Some(Token::Number(n)) => n,
             _ => return Err("Expected a number for the X coordinate"),

--- a/src/types/geometrycollection.rs
+++ b/src/types/geometrycollection.rs
@@ -12,21 +12,30 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+extern crate num_traits;
+
 use std::fmt;
+use std::str::FromStr;
 use tokenizer::{PeekableTokens, Token};
 use FromTokens;
 use Geometry;
 
 #[derive(Default)]
-pub struct GeometryCollection(pub Vec<Geometry>);
+pub struct GeometryCollection<T: num_traits::Float>(pub Vec<Geometry<T>>);
 
-impl GeometryCollection {
-    pub fn as_item(self) -> Geometry {
+impl<T> GeometryCollection<T>
+where
+    T: num_traits::Float
+{
+    pub fn as_item(self) -> Geometry<T> {
         Geometry::GeometryCollection(self)
     }
 }
 
-impl fmt::Display for GeometryCollection {
+impl<T> fmt::Display for GeometryCollection<T>
+where
+    T: num_traits::Float + fmt::Display
+{
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         if self.0.is_empty() {
             f.write_str("GEOMETRYCOLLECTION EMPTY")
@@ -43,8 +52,11 @@ impl fmt::Display for GeometryCollection {
     }
 }
 
-impl FromTokens for GeometryCollection {
-    fn from_tokens(tokens: &mut PeekableTokens) -> Result<Self, &'static str> {
+impl<T> FromTokens<T> for GeometryCollection<T>
+where
+    T: num_traits::Float + FromStr + Default
+{
+    fn from_tokens(tokens: &mut PeekableTokens<T>) -> Result<Self, &'static str> {
         let mut items = Vec::new();
 
         let word = match tokens.next() {
@@ -79,7 +91,7 @@ mod tests {
 
     #[test]
     fn basic_geometrycollection() {
-        let mut wkt = Wkt::from_str("GEOMETRYCOLLECTION (POINT (8 4)))")
+        let mut wkt: Wkt<f64> = Wkt::from_str("GEOMETRYCOLLECTION (POINT (8 4)))")
             .ok()
             .unwrap();
         assert_eq!(1, wkt.items.len());
@@ -92,7 +104,7 @@ mod tests {
 
     #[test]
     fn complex_geometrycollection() {
-        let mut wkt = Wkt::from_str("GEOMETRYCOLLECTION (POINT (8 4),LINESTRING(4 6,7 10)))")
+        let mut wkt: Wkt<f64> = Wkt::from_str("GEOMETRYCOLLECTION (POINT (8 4),LINESTRING(4 6,7 10)))")
             .ok()
             .unwrap();
         assert_eq!(1, wkt.items.len());
@@ -105,7 +117,7 @@ mod tests {
 
     #[test]
     fn write_empty_geometry_collection() {
-        let geometry_collection = GeometryCollection(vec![]);
+        let geometry_collection: GeometryCollection<f64> = GeometryCollection(vec![]);
 
         assert_eq!(
             "GEOMETRYCOLLECTION EMPTY",

--- a/src/types/linestring.rs
+++ b/src/types/linestring.rs
@@ -12,29 +12,41 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+extern crate num_traits;
+
 use std::fmt;
+use std::str::FromStr;
 use tokenizer::PeekableTokens;
 use types::coord::Coord;
 use FromTokens;
 use Geometry;
 
 #[derive(Default)]
-pub struct LineString(pub Vec<Coord>);
+pub struct LineString<T: num_traits::Float>(pub Vec<Coord<T>>);
 
-impl LineString {
-    pub fn as_item(self) -> Geometry {
+impl<T> LineString<T>
+where
+    T: num_traits::Float
+{
+    pub fn as_item(self) -> Geometry<T> {
         Geometry::LineString(self)
     }
 }
 
-impl FromTokens for LineString {
-    fn from_tokens(tokens: &mut PeekableTokens) -> Result<Self, &'static str> {
-        let result = FromTokens::comma_many(<Coord as FromTokens>::from_tokens, tokens);
+impl<T> FromTokens<T> for LineString<T>
+where
+    T: num_traits::Float + FromStr + Default
+{
+    fn from_tokens(tokens: &mut PeekableTokens<T>) -> Result<Self, &'static str> {
+        let result = FromTokens::comma_many(<Coord<T> as FromTokens<T>>::from_tokens, tokens);
         result.map(LineString)
     }
 }
 
-impl fmt::Display for LineString {
+impl<T> fmt::Display for LineString<T>
+where
+    T: num_traits::Float + fmt::Display
+{
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         if self.0.is_empty() {
             f.write_str("LINESTRING EMPTY")
@@ -79,7 +91,7 @@ mod tests {
 
     #[test]
     fn write_empty_linestring() {
-        let linestring = LineString(vec![]);
+        let linestring: LineString<f64> = LineString(vec![]);
 
         assert_eq!("LINESTRING EMPTY", format!("{}", linestring));
     }

--- a/src/types/polygon.rs
+++ b/src/types/polygon.rs
@@ -12,22 +12,31 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+extern crate num_traits;
+
 use std::fmt;
+use std::str::FromStr;
 use tokenizer::PeekableTokens;
 use types::linestring::LineString;
 use FromTokens;
 use Geometry;
 
 #[derive(Default)]
-pub struct Polygon(pub Vec<LineString>);
+pub struct Polygon<T: num_traits::Float>(pub Vec<LineString<T>>);
 
-impl Polygon {
-    pub fn as_item(self) -> Geometry {
+impl<T> Polygon<T>
+where
+    T: num_traits::Float
+{
+    pub fn as_item(self) -> Geometry<T> {
         Geometry::Polygon(self)
     }
 }
 
-impl fmt::Display for Polygon {
+impl<T> fmt::Display for Polygon<T>
+where
+    T: num_traits::Float + fmt::Display
+{
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         if self.0.is_empty() {
             f.write_str("POLYGON EMPTY")
@@ -48,10 +57,13 @@ impl fmt::Display for Polygon {
     }
 }
 
-impl FromTokens for Polygon {
-    fn from_tokens(tokens: &mut PeekableTokens) -> Result<Self, &'static str> {
+impl<T> FromTokens<T> for Polygon<T>
+where
+    T: num_traits::Float + FromStr + Default
+{
+    fn from_tokens(tokens: &mut PeekableTokens<T>) -> Result<Self, &'static str> {
         let result =
-            FromTokens::comma_many(<LineString as FromTokens>::from_tokens_with_parens, tokens);
+            FromTokens::comma_many(<LineString<T> as FromTokens<T>>::from_tokens_with_parens, tokens);
         result.map(Polygon)
     }
 }
@@ -64,7 +76,7 @@ mod tests {
 
     #[test]
     fn basic_polygon() {
-        let mut wkt = Wkt::from_str("POLYGON ((8 4, 4 0, 0 4, 8 4), (7 3, 4 1, 1 4, 7 3))")
+        let mut wkt: Wkt<f64> = Wkt::from_str("POLYGON ((8 4, 4 0, 0 4, 8 4), (7 3, 4 1, 1 4, 7 3))")
             .ok()
             .unwrap();
         assert_eq!(1, wkt.items.len());
@@ -77,7 +89,7 @@ mod tests {
 
     #[test]
     fn write_empty_polygon() {
-        let polygon = Polygon(vec![]);
+        let polygon: Polygon<f64> = Polygon(vec![]);
 
         assert_eq!("POLYGON EMPTY", format!("{}", polygon));
     }


### PR DESCRIPTION
Attempt to close #33. I based this off of the conversion implementation in [geojson](https://github.com/georust/geojson/blob/master/src/conversion.rs) and only used generic types for converting to `geo_types` objects

Initially I tried to update the `From` trait implementation, but I used `Into` instead because updating `From` gave me the following error:

```
type parameter `T` must be used as the type parameter for some local type
```

If I missed something that would make `From` work instead I can make that change. Let me know if I should change that or anything else here, thanks!