### PR TITLE
update to the last geo_types version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 keywords = ["geo", "geospatial", "wkt"]
 
 [dependencies]
-geo-types = {version = "0.4", optional = true}
+geo-types = {version = "0.5", optional = true}
 num-traits = "0.2"
 
 [dev-dependencies]


### PR DESCRIPTION
Hello, I encountered this bug and I fixed by updating `geo_types`. I tested the patch with `cargo test` and it works.

```   |
107 |           let multi_polygon = match wkt::conversion::try_into_geometry(&wkt_shape)                                            
    |  ___________________________________-
108 | |             .expect("Failed to convert polygon wkt to geo_types")                                                           
    | |_________________________________________________________________- this expression has type `geo_types::geometry::Geometry<f64>`
109 |           {
110 |               Geometry::MultiPolygon(multi_polygon) => multi_polygon,                                                         
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected enum `geo_types::geometry::Geometry`, found a different enum `geo_types::geometry::Geometry`
    |
    = note: expected enum `geo_types::geometry::Geometry<f64>`
               found enum `geo_types::geometry::Geometry<_>`
    = note: perhaps two different versions of crate `geo_types` are being used?  
```