### PR TITLE
Try/From<Wkt> traits for Geometry

### DIFF
--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -15,9 +15,12 @@
 extern crate geo_types;
 extern crate num_traits;
 
-use std::fmt;
 use types::*;
 use Geometry;
+use Wkt;
+
+use std::convert::{TryFrom, TryInto};
+use std::fmt;
 
 #[derive(Debug)]
 pub enum Error {
@@ -34,146 +37,225 @@ impl fmt::Display for Error {
     }
 }
 
-fn create_geo_coordinate<T>(coord: &Coord<T>) -> geo_types::Coordinate<T>
+impl<T> TryFrom<Wkt<T>> for geo_types::Geometry<T>
 where
     T: num_traits::Float,
 {
-    geo_types::Coordinate {
-        x: T::from(coord.x).unwrap(),
-        y: T::from(coord.y).unwrap(),
-    }
-}
+    type Error = Error;
 
-fn try_into_point<T>(point: &Point<T>) -> Result<geo_types::Geometry<T>, Error>
-where
-    T: num_traits::Float,
-{
-    match point.0 {
-        Some(ref c) => {
-            let geo_point: geo_types::Point<T> = (c.x, c.y).into();
-            Ok(geo_point.into())
+    fn try_from(mut wkt: Wkt<T>) -> Result<Self, Self::Error> {
+        if wkt.items.len() == 1 {
+            Self::try_from(wkt.items.pop().unwrap())
+        } else {
+            Geometry::GeometryCollection(GeometryCollection(wkt.items)).try_into()
         }
-        None => Err(Error::PointConversionError),
     }
 }
 
+impl<T> From<Coord<T>> for geo_types::Coordinate<T>
+where
+    T: num_traits::Float,
+{
+    fn from(coord: Coord<T>) -> geo_types::Coordinate<T> {
+        Self {
+            x: coord.x,
+            y: coord.y,
+        }
+    }
+}
+
+impl<T> TryFrom<Point<T>> for geo_types::Point<T>
+where
+    T: num_traits::Float,
+{
+    type Error = Error;
+
+    fn try_from(point: Point<T>) -> Result<Self, Self::Error> {
+        match point.0 {
+            Some(coord) => Ok(Self::new(coord.x, coord.y)),
+            None => Err(Error::PointConversionError),
+        }
+    }
+}
+
+#[deprecated(since = "0.9", note = "use `geometry.try_into()` instead")]
 pub fn try_into_geometry<T>(geometry: &Geometry<T>) -> Result<geo_types::Geometry<T>, Error>
 where
     T: num_traits::Float,
 {
-    match geometry {
-        Geometry::Point(point) => try_into_point(point),
-        Geometry::LineString(linestring) => Ok(linestring.into()),
-        Geometry::Polygon(polygon) => Ok(polygon.into()),
-        Geometry::MultiLineString(multilinestring) => Ok(multilinestring.into()),
-        Geometry::MultiPoint(multipoint) => Ok(multipoint.into()),
-        Geometry::MultiPolygon(multipolygon) => Ok(multipolygon.into()),
-        Geometry::GeometryCollection(geometrycollection) => {
-            try_into_geometry_collection(geometrycollection)
+    geometry.clone().try_into()
+}
+
+impl<'a, T> From<&'a LineString<T>> for geo_types::Geometry<T>
+where
+    T: num_traits::Float,
+{
+    fn from(line_string: &'a LineString<T>) -> Self {
+        Self::LineString(line_string.clone().into())
+    }
+}
+
+impl<T> From<LineString<T>> for geo_types::LineString<T>
+where
+    T: num_traits::Float,
+{
+    fn from(line_string: LineString<T>) -> Self {
+        let coords = line_string
+            .0
+            .into_iter()
+            .map(geo_types::Coordinate::from)
+            .collect();
+
+        geo_types::LineString(coords)
+    }
+}
+
+impl<'a, T> From<&'a MultiLineString<T>> for geo_types::Geometry<T>
+where
+    T: num_traits::Float,
+{
+    fn from(multi_line_string: &'a MultiLineString<T>) -> geo_types::Geometry<T> {
+        Self::MultiLineString(multi_line_string.clone().into())
+    }
+}
+
+impl<T> From<MultiLineString<T>> for geo_types::MultiLineString<T>
+where
+    T: num_traits::Float,
+{
+    fn from(multi_line_string: MultiLineString<T>) -> geo_types::MultiLineString<T> {
+        let geo_line_strings: Vec<geo_types::LineString<T>> = multi_line_string
+            .0
+            .into_iter()
+            .map(geo_types::LineString::from)
+            .collect();
+
+        geo_types::MultiLineString(geo_line_strings)
+    }
+}
+
+impl<'a, T> From<&'a Polygon<T>> for geo_types::Geometry<T>
+where
+    T: num_traits::Float,
+{
+    fn from(polygon: &'a Polygon<T>) -> geo_types::Geometry<T> {
+        Self::Polygon(polygon.clone().into())
+    }
+}
+
+impl<T> From<Polygon<T>> for geo_types::Polygon<T>
+where
+    T: num_traits::Float,
+{
+    fn from(polygon: Polygon<T>) -> Self {
+        let mut iter = polygon.0.into_iter().map(geo_types::LineString::from);
+        match iter.next() {
+            Some(interior) => geo_types::Polygon::new(interior, iter.collect()),
+            None => geo_types::Polygon::new(geo_types::LineString(vec![]), vec![]),
         }
     }
 }
 
-impl<'a, T> Into<geo_types::Geometry<T>> for &'a LineString<T>
+impl<'a, T> TryFrom<&'a MultiPoint<T>> for geo_types::Geometry<T>
 where
     T: num_traits::Float,
 {
-    fn into(self) -> geo_types::Geometry<T> {
-        let geo_linestring: geo_types::LineString<T> =
-            self.0.iter().map(|c| create_geo_coordinate(&c)).collect();
+    type Error = Error;
 
-        geo_linestring.into()
+    fn try_from(multi_point: &'a MultiPoint<T>) -> Result<Self, Self::Error> {
+        Ok(Self::MultiPoint(multi_point.clone().try_into()?))
     }
 }
 
-impl<'a, T> Into<geo_types::Geometry<T>> for &'a MultiLineString<T>
+impl<T> TryFrom<MultiPoint<T>> for geo_types::MultiPoint<T>
 where
     T: num_traits::Float,
 {
-    fn into(self) -> geo_types::Geometry<T> {
-        let geo_multilinestring: geo_types::MultiLineString<T> = self
+    type Error = Error;
+
+    fn try_from(multi_point: MultiPoint<T>) -> Result<Self, Self::Error> {
+        let points: Vec<geo_types::Point<T>> = multi_point
             .0
-            .iter()
-            .map(|l| {
-                l.0.iter()
-                    .map(|c| create_geo_coordinate(&c))
-                    .collect::<Vec<_>>()
-            })
+            .into_iter()
+            .map(geo_types::Point::try_from)
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(geo_types::MultiPoint(points))
+    }
+}
+
+impl<'a, T> From<&'a MultiPolygon<T>> for geo_types::Geometry<T>
+where
+    T: num_traits::Float,
+{
+    fn from(multi_polygon: &'a MultiPolygon<T>) -> Self {
+        Self::MultiPolygon(multi_polygon.clone().into())
+    }
+}
+
+impl<T> From<MultiPolygon<T>> for geo_types::MultiPolygon<T>
+where
+    T: num_traits::Float,
+{
+    fn from(multi_polygon: MultiPolygon<T>) -> Self {
+        let geo_polygons: Vec<geo_types::Polygon<T>> = multi_polygon
+            .0
+            .into_iter()
+            .map(geo_types::Polygon::from)
             .collect();
 
-        geo_multilinestring.into()
+        geo_types::MultiPolygon(geo_polygons)
     }
 }
 
-fn w_polygon_to_g_polygon<T>(polygon: &Polygon<T>) -> geo_types::Polygon<T>
-where
-    T: num_traits::Float,
-{
-    let mut iter = polygon.0.iter().map(|l| {
-        l.0.iter()
-            .map(|c| create_geo_coordinate(c))
-            .collect::<Vec<_>>()
-            .into()
-    });
-
-    match iter.next() {
-        Some(interior) => geo_types::Polygon::new(interior, iter.collect()),
-        None => geo_types::Polygon::new(geo_types::LineString(vec![]), vec![]),
-    }
-}
-
-impl<'a, T> Into<geo_types::Geometry<T>> for &'a Polygon<T>
-where
-    T: num_traits::Float,
-{
-    fn into(self) -> geo_types::Geometry<T> {
-        w_polygon_to_g_polygon(self).into()
-    }
-}
-
-impl<'a, T> Into<geo_types::Geometry<T>> for &'a MultiPoint<T>
-where
-    T: num_traits::Float,
-{
-    fn into(self) -> geo_types::Geometry<T> {
-        let geo_multipoint: geo_types::MultiPoint<T> = self
-            .0
-            .iter()
-            .filter_map(|p| p.0.as_ref())
-            .map(|c| create_geo_coordinate(c))
-            .collect();
-
-        geo_multipoint.into()
-    }
-}
-
-impl<'a, T> Into<geo_types::Geometry<T>> for &'a MultiPolygon<T>
-where
-    T: num_traits::Float,
-{
-    fn into(self) -> geo_types::Geometry<T> {
-        let geo_multipolygon: geo_types::MultiPolygon<T> =
-            self.0.iter().map(|p| w_polygon_to_g_polygon(p)).collect();
-
-        geo_multipolygon.into()
-    }
-}
-
+#[deprecated(since = "0.9", note = "use `geometry_collection.try_into()` instead")]
 pub fn try_into_geometry_collection<T>(
-    geometrycollection: &GeometryCollection<T>,
+    geometry_collection: &GeometryCollection<T>,
 ) -> Result<geo_types::Geometry<T>, Error>
 where
     T: num_traits::Float,
 {
-    let geo_geometrycollection: geo_types::GeometryCollection<T> = geometrycollection
-        .0
-        .iter()
-        .map(|g| try_into_geometry(g))
-        .collect::<Result<_, _>>()?;
-
     Ok(geo_types::Geometry::GeometryCollection(
-        geo_geometrycollection,
+        geometry_collection.clone().try_into()?,
     ))
+}
+
+impl<T> TryFrom<GeometryCollection<T>> for geo_types::GeometryCollection<T>
+where
+    T: num_traits::Float,
+{
+    type Error = Error;
+
+    fn try_from(geometry_collection: GeometryCollection<T>) -> Result<Self, Self::Error> {
+        let geo_geometeries = geometry_collection
+            .0
+            .into_iter()
+            .map(Geometry::try_into)
+            .collect::<Result<_, _>>()?;
+
+        Ok(geo_types::GeometryCollection(geo_geometeries))
+    }
+}
+
+impl<T> TryFrom<Geometry<T>> for geo_types::Geometry<T>
+where
+    T: num_traits::Float,
+{
+    type Error = Error;
+
+    fn try_from(geometry: Geometry<T>) -> Result<Self, Self::Error> {
+        Ok(match geometry {
+            Geometry::Point(g) => geo_types::Geometry::Point(g.try_into()?),
+            Geometry::LineString(g) => geo_types::Geometry::LineString(g.into()),
+            Geometry::Polygon(g) => geo_types::Geometry::Polygon(g.into()),
+            Geometry::MultiLineString(g) => geo_types::Geometry::MultiLineString(g.into()),
+            Geometry::MultiPoint(g) => geo_types::Geometry::MultiPoint(g.try_into()?),
+            Geometry::MultiPolygon(g) => geo_types::Geometry::MultiPolygon(g.into()),
+            Geometry::GeometryCollection(g) => {
+                geo_types::Geometry::GeometryCollection(g.try_into()?)
+            }
+        })
+    }
 }
 
 #[cfg(test)]
@@ -181,9 +263,60 @@ mod tests {
     use super::*;
 
     #[test]
+    fn convert_single_item_wkt() {
+        let w_point = Point(Some(Coord {
+            x: 1.0,
+            y: 2.0,
+            z: None,
+            m: None,
+        }))
+        .as_item();
+        let mut wkt = Wkt::new();
+        wkt.add_item(w_point);
+
+        let converted = geo_types::Geometry::try_from(wkt).unwrap();
+        let g_point: geo_types::Point<f64> = geo_types::Point::new(1.0, 2.0);
+
+        assert_eq!(converted, geo_types::Geometry::Point(g_point));
+    }
+
+    #[test]
+    fn convert_collection_wkt() {
+        let w_point_1 = Point(Some(Coord {
+            x: 1.0,
+            y: 2.0,
+            z: None,
+            m: None,
+        }))
+        .as_item();
+        let w_point_2 = Point(Some(Coord {
+            x: 3.0,
+            y: 4.0,
+            z: None,
+            m: None,
+        }))
+        .as_item();
+        let mut wkt = Wkt::new();
+        wkt.add_item(w_point_1);
+        wkt.add_item(w_point_2);
+
+        let converted = geo_types::Geometry::try_from(wkt).unwrap();
+        let geo_collection: geo_types::GeometryCollection<f64> =
+            geo_types::GeometryCollection(vec![
+                geo_types::Point::new(1.0, 2.0).into(),
+                geo_types::Point::new(3.0, 4.0).into(),
+            ]);
+
+        assert_eq!(
+            converted,
+            geo_types::Geometry::GeometryCollection(geo_collection)
+        );
+    }
+
+    #[test]
     fn convert_empty_point() {
         let point = Point(None).as_item();
-        let res: Result<geo_types::Geometry<f64>, Error> = try_into_geometry(&point);
+        let res: Result<geo_types::Geometry<f64>, Error> = point.try_into();
         assert!(res.is_err());
     }
 
@@ -200,7 +333,7 @@ mod tests {
         let g_point: geo_types::Point<f64> = (10., 20.).into();
         assert_eq!(
             geo_types::Geometry::Point(g_point),
-            try_into_geometry(&point).unwrap()
+            point.try_into().unwrap()
         );
     }
 
@@ -210,7 +343,7 @@ mod tests {
         let g_linestring: geo_types::LineString<f64> = geo_types::LineString(vec![]);
         assert_eq!(
             geo_types::Geometry::LineString(g_linestring),
-            try_into_geometry(&w_linestring).unwrap()
+            w_linestring.try_into().unwrap()
         );
     }
 
@@ -234,7 +367,7 @@ mod tests {
         let g_linestring: geo_types::LineString<f64> = vec![(10., 20.), (30., 40.)].into();
         assert_eq!(
             geo_types::Geometry::LineString(g_linestring),
-            try_into_geometry(&w_linestring).unwrap()
+            w_linestring.try_into().unwrap()
         );
     }
 
@@ -245,7 +378,7 @@ mod tests {
             geo_types::Polygon::new(geo_types::LineString(vec![]), vec![]);
         assert_eq!(
             geo_types::Geometry::Polygon(g_polygon),
-            try_into_geometry(&w_polygon).unwrap()
+            w_polygon.try_into().unwrap()
         );
     }
 
@@ -312,7 +445,7 @@ mod tests {
         );
         assert_eq!(
             geo_types::Geometry::Polygon(g_polygon),
-            try_into_geometry(&w_polygon).unwrap()
+            w_polygon.try_into().unwrap()
         );
     }
 
@@ -322,7 +455,7 @@ mod tests {
         let g_multilinestring: geo_types::MultiLineString<f64> = geo_types::MultiLineString(vec![]);
         assert_eq!(
             geo_types::Geometry::MultiLineString(g_multilinestring),
-            try_into_geometry(&w_multilinestring).unwrap()
+            w_multilinestring.try_into().unwrap()
         );
     }
 
@@ -365,7 +498,7 @@ mod tests {
         ]);
         assert_eq!(
             geo_types::Geometry::MultiLineString(g_multilinestring),
-            try_into_geometry(&w_multilinestring).unwrap()
+            w_multilinestring.try_into().unwrap()
         );
     }
 
@@ -375,7 +508,7 @@ mod tests {
         let g_multipoint: geo_types::MultiPoint<f64> = geo_types::MultiPoint(vec![]);
         assert_eq!(
             geo_types::Geometry::MultiPoint(g_multipoint),
-            try_into_geometry(&w_multipoint).unwrap()
+            w_multipoint.try_into().unwrap()
         );
     }
 
@@ -399,7 +532,7 @@ mod tests {
         let g_multipoint: geo_types::MultiPoint<f64> = vec![(10., 20.), (30., 40.)].into();
         assert_eq!(
             geo_types::Geometry::MultiPoint(g_multipoint),
-            try_into_geometry(&w_multipoint).unwrap()
+            w_multipoint.try_into().unwrap()
         );
     }
 
@@ -409,7 +542,7 @@ mod tests {
         let g_multipolygon: geo_types::MultiPolygon<f64> = geo_types::MultiPolygon(vec![]);
         assert_eq!(
             geo_types::Geometry::MultiPolygon(g_multipolygon),
-            try_into_geometry(&w_multipolygon).unwrap()
+            w_multipolygon.try_into().unwrap()
         );
     }
 
@@ -511,7 +644,7 @@ mod tests {
         ]);
         assert_eq!(
             geo_types::Geometry::MultiPolygon(g_multipolygon),
-            try_into_geometry(&w_multipolygon).unwrap()
+            w_multipolygon.try_into().unwrap()
         );
     }
 
@@ -522,7 +655,7 @@ mod tests {
             geo_types::GeometryCollection(vec![]);
         assert_eq!(
             geo_types::Geometry::GeometryCollection(g_geometrycollection),
-            try_into_geometry(&w_geometrycollection).unwrap()
+            w_geometrycollection.try_into().unwrap()
         );
     }
 
@@ -727,7 +860,7 @@ mod tests {
             ]);
         assert_eq!(
             geo_types::Geometry::GeometryCollection(g_geometrycollection),
-            try_into_geometry(&w_geometrycollection).unwrap()
+            w_geometrycollection.try_into().unwrap()
         );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,7 @@ pub use towkt::ToWkt;
 #[cfg(feature = "geo-types")]
 pub mod conversion;
 
+#[derive(Clone)]
 pub enum Geometry<T>
 where
     T: num_traits::Float,
@@ -112,6 +113,7 @@ where
     }
 }
 
+#[derive(Clone)]
 pub struct Wkt<T>
 where
     T: num_traits::Float,

--- a/src/types/coord.rs
+++ b/src/types/coord.rs
@@ -19,7 +19,7 @@ use std::str::FromStr;
 use tokenizer::{PeekableTokens, Token};
 use FromTokens;
 
-#[derive(Default)]
+#[derive(Clone, Default)]
 pub struct Coord<T>
 where
     T: num_traits::Float,

--- a/src/types/geometrycollection.rs
+++ b/src/types/geometrycollection.rs
@@ -20,7 +20,7 @@ use tokenizer::{PeekableTokens, Token};
 use FromTokens;
 use Geometry;
 
-#[derive(Default)]
+#[derive(Clone, Default)]
 pub struct GeometryCollection<T: num_traits::Float>(pub Vec<Geometry<T>>);
 
 impl<T> GeometryCollection<T>

--- a/src/types/linestring.rs
+++ b/src/types/linestring.rs
@@ -21,7 +21,7 @@ use types::coord::Coord;
 use FromTokens;
 use Geometry;
 
-#[derive(Default)]
+#[derive(Clone, Default)]
 pub struct LineString<T: num_traits::Float>(pub Vec<Coord<T>>);
 
 impl<T> LineString<T>

--- a/src/types/multilinestring.rs
+++ b/src/types/multilinestring.rs
@@ -21,7 +21,7 @@ use types::linestring::LineString;
 use FromTokens;
 use Geometry;
 
-#[derive(Default)]
+#[derive(Clone, Default)]
 pub struct MultiLineString<T: num_traits::Float>(pub Vec<LineString<T>>);
 
 impl<T> MultiLineString<T>

--- a/src/types/multipoint.rs
+++ b/src/types/multipoint.rs
@@ -21,7 +21,7 @@ use types::point::Point;
 use FromTokens;
 use Geometry;
 
-#[derive(Default)]
+#[derive(Clone, Default)]
 pub struct MultiPoint<T: num_traits::Float>(pub Vec<Point<T>>);
 
 impl<T> MultiPoint<T>

--- a/src/types/multipolygon.rs
+++ b/src/types/multipolygon.rs
@@ -21,7 +21,7 @@ use types::polygon::Polygon;
 use FromTokens;
 use Geometry;
 
-#[derive(Default)]
+#[derive(Clone, Default)]
 pub struct MultiPolygon<T: num_traits::Float>(pub Vec<Polygon<T>>);
 
 impl<T> MultiPolygon<T>

--- a/src/types/point.rs
+++ b/src/types/point.rs
@@ -21,7 +21,7 @@ use types::coord::Coord;
 use FromTokens;
 use Geometry;
 
-#[derive(Default)]
+#[derive(Clone, Default)]
 pub struct Point<T: num_traits::Float>(pub Option<Coord<T>>);
 
 impl<T> Point<T>

--- a/src/types/polygon.rs
+++ b/src/types/polygon.rs
@@ -21,7 +21,7 @@ use types::linestring::LineString;
 use FromTokens;
 use Geometry;
 
-#[derive(Default)]
+#[derive(Clone, Default)]
 pub struct Polygon<T: num_traits::Float>(pub Vec<LineString<T>>);
 
 impl<T> Polygon<T>


### PR DESCRIPTION
This is a couple separate but related things...

The main new functionality is that you can call `Geometry::from(wkt)`

Along the way, I replaced the `Try/Into` impls with `Try/From`. We should prefer TryFrom where possible since it is sometimes nicer to use and also gives you the TryInto impl for free.

Correspondingly, I deprecated methods like `try_into_geometry` in favor of `geometry.try_into` which I think is more discoverable.

One thing I was curious about - I think conventionally conversions are done via move, so the caller is responsible for any cloning, but previously all our conversions were done via references and our impls were creating new points for everything. That seemed a little strange to me, so I implemented all the new ones with the move semantics that I'm used to. I did leave the existing functionality (but rephrased them as `From`) so as not to break the API.

A couple potentially controversial things I'll call out inline...