### PR TITLE
specific errors and `try_into` for inner geo-types

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+* WKT errors impl `std::error::Error`
+  * <https://github.com/georust/wkt/pull/56/>
+* Add TryFrom for converting directly to geo-types::Geometry enum members, such
+  as `geo_types::LineString::try_from(wkt)`
+  * <https://github.com/georust/wkt/pull/56/>
 * Add `geo-types::Geometry::from(wkt)`
 * BREAKING: update geo-types, apply new `geo_types::CoordFloat`
   * <https://github.com/georust/wkt/pull/53>

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ keywords = ["geo", "geospatial", "wkt"]
 [dependencies]
 geo-types = {version = "0.7", optional = true}
 num-traits = "0.2"
+thiserror = "1.0.23"
 
 [dev-dependencies]
 criterion = { version = "0.2" }
@@ -22,3 +23,12 @@ default = ["geo-types"]
 [[bench]]
 name = "parse"
 harness = false
+
+[patch.crates-io]
+# This feature depends on an unmerged geo-types feature.
+# Once (and if) that geo-types feature is released, we can merge this and bump
+# the min version of geo-types required.
+# That's a breaking change for wkt, but we already have an unreleased breaking
+# change for WKT in the pipeline, so I'd recommend combinging them into one
+# breaking WKT release.
+geo-types = { git = "https://github.com/georust/geo", branch = "mkirk/pub-error" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,8 @@ pub mod types;
 #[cfg(feature = "geo-types")]
 extern crate geo_types;
 
+extern crate thiserror;
+
 #[cfg(feature = "geo-types")]
 pub use towkt::ToWkt;
 


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

Add TryFrom for converting directly to `geo_types::Geometry` enum members. 

```
let ls: geo_types::LineString = geo_types::LineString::try_from(wkt).unwrap();
```

This introduced two new error cases, so I've introduced `thiserror` which solves #49

FIXES https://github.com/georust/wkt/issues/49