### PR TITLE
specific errors and `try_into` for inner geo-types

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+* WKT errors impl `std::error::Error`
+  * <https://github.com/georust/wkt/pull/57>
+* Add TryFrom for converting directly to geo-types::Geometry enum members, such
+  as `geo_types::LineString::try_from(wkt)`
+  * <https://github.com/georust/wkt/pull/57>
 * Add `geo-types::Geometry::from(wkt)`
 * BREAKING: update geo-types, apply new `geo_types::CoordFloat`
   * <https://github.com/georust/wkt/pull/53>

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,9 @@ readme = "README.md"
 keywords = ["geo", "geospatial", "wkt"]
 
 [dependencies]
-geo-types = {version = "0.7", optional = true}
+geo-types = {version = "0.7.1", optional = true}
 num-traits = "0.2"
+thiserror = "1.0.23"
 
 [dev-dependencies]
 criterion = { version = "0.2" }
@@ -22,3 +23,4 @@ default = ["geo-types"]
 [[bench]]
 name = "parse"
 harness = false
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,8 @@ pub mod types;
 #[cfg(feature = "geo-types")]
 extern crate geo_types;
 
+extern crate thiserror;
+
 #[cfg(feature = "geo-types")]
 pub use towkt::ToWkt;
 


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

**DRAFT**: depends on https://github.com/georust/geo/pull/614 being released first.

Add TryFrom for converting directly to `geo_types::Geometry` enum members. 

```
let ls: geo_types::LineString = geo_types::LineString::try_from(wkt).unwrap();
```

Previously it was:
```
let geom: geo_types::Geometry = geo_types::Geometry::from(wkt).unwrap();
let ls: geo_types::LineString = geo_types::LineString::try_from(geom).unwrap();
```


This introduced two new error cases, so I've also introduced `thiserror` which solves #49

FIXES https://github.com/georust/wkt/issues/49