### PR TITLE
add docs/crates badge. remove deprecated CI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,15 @@
 wkt
 ===
 
-[![Build Status](https://travis-ci.org/georust/wkt.svg?branch=master)](https://travis-ci.org/georust/wkt)
-
-[API Documentation](https://docs.rs/wkt/)
-
 Rust read/write support for [well-known text (WKT)](https://en.wikipedia.org/wiki/Well-known_text).
+
+[![Crate][crates-badge]][crates-url]
+[![API Documentation][docs-badge]][docs-url]
+
+[crates-badge]: https://img.shields.io/crates/v/wkt.svg
+[crates-url]: https://crates.io/crates/wkt
+[docs-badge]: https://docs.rs/wkt/badge.svg
+[docs-url]: https://docs.rs/wkt
 
 ## License
 


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [n/a] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

Added a docs/crates badge.

🔥hot take🔥:  I removed the ci badge all together.
we no longer use travis ci. I could have changed this to use a GH actions
badge, but people can already see the build status next to the commit on
the front page. I don't think it warrants a redundant badge.


