### PR TITLE
deserialize point

### DIFF
--- a/src/deserialize.rs
+++ b/src/deserialize.rs
@@ -130,7 +130,7 @@ where
 /// # extern crate wkt;
 /// # extern crate geo_types;
 /// # extern crate serde_json;
-/// use geo_types::Geometry;
+/// use geo_types::Point;
 ///
 /// #[derive(serde::Deserialize)]
 /// struct MyType {

--- a/src/deserialize.rs
+++ b/src/deserialize.rs
@@ -126,6 +126,9 @@ where
 
 /// Deserializes directly from WKT format into a `Option<geo_types::Point>`.
 ///
+/// # Examples
+///
+///
 /// ```
 /// # extern crate wkt;
 /// # extern crate geo_types;

--- a/src/deserialize.rs
+++ b/src/deserialize.rs
@@ -94,7 +94,7 @@ where
     }
 }
 
-/// This is a helper function to convert directly from WKT format into a geo_types::Geometry.
+/// Deserializes directly from WKT format into a geo_types::Geometry.
 /// ```
 /// # extern crate wkt;
 /// # extern crate geo_types;
@@ -121,6 +121,49 @@ where
     Geometry::deserialize(deserializer).and_then(|g: Geometry<T>| {
         use std::convert::TryInto;
         g.try_into().map_err(|e| D::Error::custom(e))
+    })
+}
+
+/// Deserializes directly from WKT format into a `Option<geo_types::Point>`.
+///
+/// ```
+/// # extern crate wkt;
+/// # extern crate geo_types;
+/// # extern crate serde_json;
+/// use geo_types::Geometry;
+///
+/// #[derive(serde::Deserialize)]
+/// struct MyType {
+///     #[serde(deserialize_with = "wkt::deserialize_point")]
+///     pub geometry: Option<Point<f64>>,
+/// }
+///
+/// let json = r#"{ "geometry": "POINT (3.14 42)" }"#;
+/// let my_type: MyType = serde_json::from_str(json).unwrap();
+/// assert!(matches!(my_type.geometry, Some(Point(_))));
+///
+/// let json = r#"{ "geometry": "POINT EMPTY" }"#;
+/// let my_type: MyType = serde_json::from_str(json).unwrap();
+/// assert!(matches!(my_type.geometry, None));
+/// ```
+#[cfg(feature = "geo-types")]
+pub fn deserialize_point<'de, D, T>(deserializer: D) -> Result<Option<geo_types::Point<T>>, D::Error>
+    where
+        D: Deserializer<'de>,
+        T: FromStr + Default + WktFloat,
+{
+    use serde::Deserialize;
+    Wkt::deserialize(deserializer).and_then(|wkt: Wkt<T>| {
+        use std::convert::TryFrom;
+        geo_types::Point::try_from(wkt).map(|p| Some(p))
+            .or_else(|e| {
+            if let crate::conversion::Error::PointConversionError = e {
+                // map a WKT: 'POINT EMPTY' to an `Option<geo_types::Point>::None`
+                return Ok(None);
+            }
+
+            Err(D::Error::custom(e))
+        })
     })
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,7 +48,7 @@ extern crate serde;
 #[cfg(feature = "serde")]
 pub mod deserialize;
 #[cfg(all(feature = "serde", feature = "geo-types"))]
-pub use deserialize::deserialize_geometry;
+pub use deserialize::{deserialize_geometry, deserialize_point};
 
 pub trait WktFloat: num_traits::Float + std::fmt::Debug {}
 impl<T> WktFloat for T where T: num_traits::Float + std::fmt::Debug {}


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [n/a] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
  -  > Add helper function for deserializing from WKT format into geo_types::Geometry
    
      I think the existing unreleased note pretty much covers it 
---

Addresses one little bit of https://github.com/georust/wkt/issues/61, though leaves unanswered the bigger questions, around how to handle `GEOMETRYCOLLETION(POINT EMPTY)` etc.

This might be controversial as it arguably muddies the water for addressing #61 more comprehensively. Please take a look at #61 for context.