### PR TITLE
Minimal support for JTS extensions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@
 * Support `POINT EMPTY` in conversion to `geo_types`.
   Converts to `MultiPoint([])`.
   * <https://github.com/georust/wkt/pull/64>
+* Minimal support for JTS extension: `LINEARRING` by parsing it as a `LINESTRING`.
 
 ## 0.9.1
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,7 +80,7 @@ where
                 let x = <Point<T> as FromTokens<T>>::from_tokens_with_parens(tokens);
                 x.map(|y| y.as_item())
             }
-            w if w.eq_ignore_ascii_case("LINESTRING") || w.eq_ignore_ascii_case("LINEARRING")  => {
+            w if w.eq_ignore_ascii_case("LINESTRING") || w.eq_ignore_ascii_case("LINEARRING") => {
                 let x = <LineString<T> as FromTokens<T>>::from_tokens_with_parens(tokens);
                 x.map(|y| y.as_item())
             }
@@ -270,7 +270,6 @@ mod tests {
             Geometry::LineString(_ls) => (),
             _ => panic!("expected to be parsed as a LINESTRING"),
         };
-
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,7 +80,7 @@ where
                 let x = <Point<T> as FromTokens<T>>::from_tokens_with_parens(tokens);
                 x.map(|y| y.as_item())
             }
-            w if w.eq_ignore_ascii_case("LINESTRING") => {
+            w if w.eq_ignore_ascii_case("LINESTRING") || w.eq_ignore_ascii_case("LINEARRING")  => {
                 let x = <LineString<T> as FromTokens<T>>::from_tokens_with_parens(tokens);
                 x.map(|y| y.as_item())
             }
@@ -259,6 +259,18 @@ mod tests {
         } else {
             panic!("Should not have parsed");
         }
+    }
+
+    #[test]
+    fn support_jts_linearring() {
+        let mut wkt: Wkt<f64> = Wkt::from_str("linearring (10 20, 30 40)").ok().unwrap();
+        assert_eq!(1, wkt.items.len());
+
+        match wkt.items.pop().unwrap() {
+            Geometry::LineString(_ls) => (),
+            _ => panic!("expected to be parsed as a LINESTRING"),
+        };
+
     }
 
     #[test]


### PR DESCRIPTION
Refer discussion in #50 

+ support LINEARRING by parsing it as a LINESTRING
+ test LINEARRING parsing

- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---


