### PR TITLE
Relax the parens requirement for multipoint

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+* Now accepts `MULTIPOINT`s with less parentheses, as output by `ST_AsText` in postgis:
+  `MULTIPOINT(0 1, 2 3)` as opposed to `MULTIPOINT((0 1), (2 3))`
+
 ## 0.9.2 - 2020-04-30
 ### Added
 * Minimal support for JTS extension: `LINEARRING` by parsing it as a `LINESTRING`.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,7 +3,7 @@
 ## Unreleased
 ### Changed
 * Now accepts `MULTIPOINT`s with less parentheses, as output by `ST_AsText` in postgis:
-  `MULTIPOINT(0 1, 2 3)` as opposed to `MULTIPOINT((0 1), (2 3))`
+  `MULTIPOINT(0 1, 2 3)` in addition to `MULTIPOINT((0 1), (2 3))`
 
 ## 0.9.2 - 2020-04-30
 ### Added

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,6 @@
 # Changes
 
 ## Unreleased
-
 ### Changed
 * Now accepts `MULTIPOINT`s with less parentheses, as output by `ST_AsText` in postgis:
   `MULTIPOINT(0 1, 2 3)` as opposed to `MULTIPOINT((0 1), (2 3))`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -194,6 +194,15 @@ where
         result
     }
 
+    fn from_tokens_with_optional_parens(
+        tokens: &mut PeekableTokens<T>,
+    ) -> Result<Self, &'static str> {
+        match tokens.peek() {
+            Some(Token::ParenOpen) => Self::from_tokens_with_parens(tokens),
+            _ => Self::from_tokens(tokens),
+        }
+    }
+
     fn comma_many<F>(f: F, tokens: &mut PeekableTokens<T>) -> Result<Vec<Self>, &'static str>
     where
         F: Fn(&mut PeekableTokens<T>) -> Result<Self, &'static str>,

--- a/src/types/multipoint.rs
+++ b/src/types/multipoint.rs
@@ -83,7 +83,7 @@ mod tests {
 
     #[test]
     fn postgis_style_multipoint() {
-        let mut wkt: Wkt<f64> = Wkt::from_str("MULTIPOINT (8 4, 4 0)").ok().unwrap();
+        let mut wkt: Wkt<f64> = Wkt::from_str("MULTIPOINT (8 4, 4 0)").unwrap();
         assert_eq!(1, wkt.items.len());
         let points = match wkt.items.pop().unwrap() {
             Geometry::MultiPoint(MultiPoint(points)) => points,
@@ -94,7 +94,7 @@ mod tests {
 
     #[test]
     fn mixed_parens_multipoint() {
-        let mut wkt: Wkt<f64> = Wkt::from_str("MULTIPOINT (8 4, (4 0))").ok().unwrap();
+        let mut wkt: Wkt<f64> = Wkt::from_str("MULTIPOINT (8 4, (4 0))").unwrap();
         assert_eq!(1, wkt.items.len());
         let points = match wkt.items.pop().unwrap() {
             Geometry::MultiPoint(MultiPoint(points)) => points,


### PR DESCRIPTION
Postgis' `ST_AsText` function will serialize multipoints like
`MULTIPOINT(0 1, 2 3)`,
which would fail to deserialize because we expect a string like
`MULTIPOINT((0 1), (2 3))`.

In fact, the Postgis `ST_GeomFromText` function even accepts mixed
bracketing, like
`MULTIPOINT((0 1), 2 3)`.

This PR updates the parsing of multipoints to allow all these styles.

- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

