### PR TITLE
Cargo fmt & clippy, run CI on PR, spelling

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,6 @@ on:
   push:
     branches:
       - main
-      - master
       - staging
       - trying
   pull_request:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,12 @@
-on: push
+on:
+  push:
+    branches:
+      - main
+      - master
+      - staging
+      - trying
+  pull_request:
+
 name: Run tests
 jobs:
   wkt:

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+.idea
 /target
 /Cargo.lock

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -12,8 +12,8 @@ This document is based on, and aims to track the [Rust Code of Conduct](https://
 * Respect that people have differences of opinion and that every design or implementation choice carries a trade-off and numerous costs. There is seldom a right answer.
 * Please keep unstructured critique to a minimum. If you have solid ideas you want to experiment with, make a fork and see how it works.
 * We will exclude you from interaction if you insult, demean or harass anyone. That is not welcome behavior. We interpret the term "harassment" as including the definition in the <a href="http://citizencodeofconduct.org/">Citizen Code of Conduct</a>; if you have any lack of clarity about what might be included in that concept, please read their definition. In particular, we don't tolerate behavior that excludes people in socially marginalized groups.
-* Private harassment is also unacceptable. No matter who you are, if you feel you have been or are being harassed or made uncomfortable by a community member, please contact one of the channel ops or any of the [GeoRust moderation team][mod_team] immediately. Whether you're a regular contributor or a newcomer, we care about making this community a safe place for you and we've got your back.
-* Likewise any spamming, trolling, flaming, baiting or other attention-stealing behavior is not welcome.
+* Private harassment is also unacceptable. No matter who you are, if you feel you have been or are being harassed or made uncomfortable by a community member, please contact one of the channel ops or any of the [GeoRust moderation team][mod_team] immediately. Whether you're a regular contributor or a newcomer, we care about making this community a safe place for you, and we've got your back.
+* Likewise, any spamming, trolling, flaming, baiting or other attention-stealing behavior is not welcome.
 
 ## Moderation
 
@@ -25,13 +25,13 @@ These are the policies for upholding our community's standards of conduct. If yo
 3. Moderators will first respond to such remarks with a warning.
 4. If the warning is unheeded, the user will be "kicked," i.e., kicked out of the communication channel to cool off.
 5. If the user comes back and continues to make trouble, they will be banned, i.e., indefinitely excluded.
-6. Moderators may choose at their discretion to un-ban the user if it was a first offense and they offer the offended party a genuine apology.
-7. If a moderator bans someone and you think it was unjustified, please take it up with that moderator, or with a different moderator, **in private**. Complaints about bans in-channel are not allowed.
+6. Moderators may choose at their discretion to un-ban the user if it was a first offense, and they offer the offended party a genuine apology.
+7. If a moderator bans someone, and you think it was unjustified, please take it up with that moderator, or with a different moderator, **in private**. Complaints about bans in-channel are not allowed.
 8. Moderators are held to a higher standard than other community members. If a moderator creates an inappropriate situation, they should expect less leeway than others.
 
 In the GeoRust community we strive to go the extra step to look out for each other. Don't just aim to be technically unimpeachable, try to be your best self. In particular, avoid flirting with offensive or sensitive issues, particularly if they're off-topic; this all too often leads to unnecessary fights, hurt feelings, and damaged trust; worse, it can drive people away from the community entirely.
 
-And if someone takes issue with something you said or did, resist the urge to be defensive. Just stop doing what it was they complained about and apologize. Even if you feel you were misinterpreted or unfairly accused, chances are good there was something you could've communicated better — remember that it's your responsibility to make your fellow Rustaceans comfortable. Everyone wants to get along and we are all here first and foremost because we want to talk about cool technology. You will find that people will be eager to assume good intent and forgive as long as you earn their trust.
+And if someone takes issue with something you said or did, resist the urge to be defensive. Just stop doing what it was they complained about and apologize. Even if you feel you were misinterpreted or unfairly accused, chances are good there was something you could've communicated better — remember that it's your responsibility to make your fellow Rustaceans comfortable. Everyone wants to get along, and we are all here first and foremost because we want to talk about cool technology. You will find that people will be eager to assume good intent and forgive as long as you earn their trust.
 
 *Adapted from the [Node.js Policy on Trolling](http://blog.izs.me/post/30036893703/policy-on-trolling) as well as the [Contributor Covenant v1.3.0](https://www.contributor-covenant.org/version/1/3/0/).*
 

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -122,7 +122,7 @@ where
     }
 }
 
-#[deprecated(since = "0.9", note = "use `geometry.try_into()` instead")]
+#[deprecated(since = "0.9.0", note = "use `geometry.try_into()` instead")]
 pub fn try_into_geometry<T>(geometry: &Geometry<T>) -> Result<geo_types::Geometry<T>, Error>
 where
     T: CoordFloat,
@@ -256,7 +256,7 @@ where
     }
 }
 
-#[deprecated(since = "0.9", note = "use `geometry_collection.try_into()` instead")]
+#[deprecated(since = "0.9.0", note = "use `geometry_collection.try_into()` instead")]
 pub fn try_into_geometry_collection<T>(
     geometry_collection: &GeometryCollection<T>,
 ) -> Result<geo_types::Geometry<T>, Error>

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -260,13 +260,13 @@ where
     type Error = Error;
 
     fn try_from(geometry_collection: GeometryCollection<T>) -> Result<Self, Self::Error> {
-        let geo_geometeries = geometry_collection
+        let geo_geometries = geometry_collection
             .0
             .into_iter()
             .map(Geometry::try_into)
             .collect::<Result<_, _>>()?;
 
-        Ok(geo_types::GeometryCollection(geo_geometeries))
+        Ok(geo_types::GeometryCollection(geo_geometries))
     }
 }
 

--- a/src/deserialize.rs
+++ b/src/deserialize.rs
@@ -115,7 +115,6 @@ where
 {
     use serde::Deserialize;
     Geometry::deserialize(deserializer).and_then(|g: Geometry<T>| {
-        use std::convert::TryInto;
         g.try_into().map_err(D::Error::custom)
     })
 }

--- a/src/deserialize.rs
+++ b/src/deserialize.rs
@@ -114,7 +114,7 @@ where
     use serde::Deserialize;
     Geometry::deserialize(deserializer).and_then(|g: Geometry<T>| {
         use std::convert::TryInto;
-        g.try_into().map_err(|e| D::Error::custom(e))
+        g.try_into().map_err(D::Error::custom)
     })
 }
 
@@ -160,7 +160,7 @@ where
                 use geo_types::Geometry::*;
                 match geom {
                     Point(p) => Ok(Some(p)),
-                    MultiPoint(mp) if mp.0.len() == 0 => Ok(None),
+                    MultiPoint(mp) if mp.0.is_empty() => Ok(None),
                     _ => geo_types::Point::try_from(geom)
                         .map(Some)
                         .map_err(D::Error::custom),

--- a/src/deserialize.rs
+++ b/src/deserialize.rs
@@ -114,9 +114,8 @@ where
     T: FromStr + Default + WktFloat,
 {
     use serde::Deserialize;
-    Geometry::deserialize(deserializer).and_then(|g: Geometry<T>| {
-        g.try_into().map_err(D::Error::custom)
-    })
+    Geometry::deserialize(deserializer)
+        .and_then(|g: Geometry<T>| g.try_into().map_err(D::Error::custom))
 }
 
 /// Deserializes directly from WKT format into an `Option<geo_types::Point>`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,7 +156,7 @@ where
         };
         match Geometry::from_word_and_tokens(&word, &mut tokens) {
             Ok(item) => Ok(Wkt { item }),
-            Err(s) => return Err(s),
+            Err(s) => Err(s),
         }
     }
 }

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -185,8 +185,7 @@ fn test_tokenizer_2numbers() {
 fn test_no_stack_overflow() {
     fn check(c: &str, count: usize, expected: usize) {
         let test_str = c.repeat(count);
-        let tokens: Vec<Token<f64>> = Tokens::from_str(&test_str).collect();
-        assert_eq!(expected, tokens.len());
+        assert_eq!(expected, Tokens::<f64>::from_str(&test_str).count());
     }
 
     let count = 100_000;

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::WktFloat;
 use std::iter::Peekable;
 use std::marker::PhantomData;
 use std::str;
-use crate::WktFloat;
 
 #[derive(Debug, PartialEq)]
 pub enum Token<T>

--- a/src/towkt.rs
+++ b/src/towkt.rs
@@ -59,7 +59,7 @@ fn g_line_to_w_linestring<T>(g_line: &geo_types::Line<T>) -> LineString<T>
 where
     T: CoordFloat,
 {
-    g_points_to_w_linestring(&vec![g_line.start, g_line.end])
+    g_points_to_w_linestring(&[g_line.start, g_line.end])
 }
 
 fn g_linestring_to_w_linestring<T>(g_linestring: &geo_types::LineString<T>) -> LineString<T>
@@ -218,7 +218,7 @@ where
     T: CoordFloat,
 {
     fn to_wkt(&self) -> Wkt<T> {
-        let w_geom = g_geom_to_w_geom(&self);
+        let w_geom = g_geom_to_w_geom(self);
         Wkt { item: w_geom }
     }
 }

--- a/src/towkt.rs
+++ b/src/towkt.rs
@@ -182,32 +182,32 @@ fn g_geom_to_w_geom<T>(g_geom: &geo_types::Geometry<T>) -> Geometry<T>
 where
     T: CoordFloat,
 {
-    match g_geom {
-        &geo_types::Geometry::Point(ref g_point) => g_point_to_w_point(g_point).as_item(),
+    match *g_geom {
+        geo_types::Geometry::Point(ref g_point) => g_point_to_w_point(g_point).as_item(),
 
-        &geo_types::Geometry::Line(ref g_line) => g_line_to_w_linestring(g_line).as_item(),
+        geo_types::Geometry::Line(ref g_line) => g_line_to_w_linestring(g_line).as_item(),
 
-        &geo_types::Geometry::LineString(ref g_line) => {
+        geo_types::Geometry::LineString(ref g_line) => {
             g_linestring_to_w_linestring(g_line).as_item()
         }
 
-        &geo_types::Geometry::Triangle(ref g_triangle) => {
+        geo_types::Geometry::Triangle(ref g_triangle) => {
             g_triangle_to_w_polygon(g_triangle).as_item()
         }
 
-        &geo_types::Geometry::Rect(ref g_rect) => g_rect_to_w_polygon(g_rect).as_item(),
+        geo_types::Geometry::Rect(ref g_rect) => g_rect_to_w_polygon(g_rect).as_item(),
 
-        &geo_types::Geometry::Polygon(ref g_polygon) => g_polygon_to_w_polygon(g_polygon).as_item(),
+        geo_types::Geometry::Polygon(ref g_polygon) => g_polygon_to_w_polygon(g_polygon).as_item(),
 
-        &geo_types::Geometry::MultiPoint(ref g_mpoint) => g_mpoint_to_w_mpoint(g_mpoint).as_item(),
+        geo_types::Geometry::MultiPoint(ref g_mpoint) => g_mpoint_to_w_mpoint(g_mpoint).as_item(),
 
-        &geo_types::Geometry::MultiLineString(ref g_mline) => g_mline_to_w_mline(g_mline).as_item(),
+        geo_types::Geometry::MultiLineString(ref g_mline) => g_mline_to_w_mline(g_mline).as_item(),
 
-        &geo_types::Geometry::MultiPolygon(ref g_mpolygon) => {
+        geo_types::Geometry::MultiPolygon(ref g_mpolygon) => {
             g_mpolygon_to_w_mpolygon(g_mpolygon).as_item()
         }
 
-        &geo_types::Geometry::GeometryCollection(ref g_geocol) => {
+        geo_types::Geometry::GeometryCollection(ref g_geocol) => {
             g_geocol_to_w_geocol(g_geocol).as_item()
         }
     }

--- a/src/types/coord.rs
+++ b/src/types/coord.rs
@@ -58,8 +58,8 @@ where
             _ => return Err("Expected a number for the Y coordinate"),
         };
         Ok(Coord {
-            x: x,
-            y: y,
+            x,
+            y,
             z: None,
             m: None,
         })

--- a/src/types/coord.rs
+++ b/src/types/coord.rs
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::fmt;
-use std::str::FromStr;
 use crate::tokenizer::{PeekableTokens, Token};
 use crate::{FromTokens, WktFloat};
+use std::fmt;
+use std::str::FromStr;
 
 #[derive(Clone, Debug, Default)]
 pub struct Coord<T>

--- a/src/types/geometrycollection.rs
+++ b/src/types/geometrycollection.rs
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::fmt;
-use std::str::FromStr;
 use crate::tokenizer::{PeekableTokens, Token};
 use crate::{FromTokens, Geometry, WktFloat};
+use std::fmt;
+use std::str::FromStr;
 
 #[derive(Clone, Debug, Default)]
 pub struct GeometryCollection<T: WktFloat>(pub Vec<Geometry<T>>);

--- a/src/types/linestring.rs
+++ b/src/types/linestring.rs
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::fmt;
-use std::str::FromStr;
 use crate::tokenizer::PeekableTokens;
 use crate::types::coord::Coord;
 use crate::{FromTokens, Geometry, WktFloat};
+use std::fmt;
+use std::str::FromStr;
 
 #[derive(Clone, Debug, Default)]
 pub struct LineString<T: WktFloat>(pub Vec<Coord<T>>);

--- a/src/types/multilinestring.rs
+++ b/src/types/multilinestring.rs
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::fmt;
-use std::str::FromStr;
 use crate::tokenizer::PeekableTokens;
 use crate::types::linestring::LineString;
 use crate::{FromTokens, Geometry, WktFloat};
+use std::fmt;
+use std::str::FromStr;
 
 #[derive(Clone, Debug, Default)]
 pub struct MultiLineString<T: WktFloat>(pub Vec<LineString<T>>);

--- a/src/types/multipoint.rs
+++ b/src/types/multipoint.rs
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::fmt;
-use std::str::FromStr;
 use crate::tokenizer::PeekableTokens;
 use crate::types::point::Point;
 use crate::{FromTokens, Geometry, WktFloat};
+use std::fmt;
+use std::str::FromStr;
 
 #[derive(Clone, Debug, Default)]
 pub struct MultiPoint<T: WktFloat>(pub Vec<Point<T>>);

--- a/src/types/multipolygon.rs
+++ b/src/types/multipolygon.rs
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::fmt;
-use std::str::FromStr;
 use crate::tokenizer::PeekableTokens;
 use crate::types::polygon::Polygon;
 use crate::{FromTokens, Geometry, WktFloat};
+use std::fmt;
+use std::str::FromStr;
 
 #[derive(Clone, Debug, Default)]
 pub struct MultiPolygon<T: WktFloat>(pub Vec<Polygon<T>>);

--- a/src/types/point.rs
+++ b/src/types/point.rs
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::fmt;
-use std::str::FromStr;
 use crate::tokenizer::PeekableTokens;
 use crate::types::coord::Coord;
 use crate::{FromTokens, Geometry, WktFloat};
+use std::fmt;
+use std::str::FromStr;
 
 #[derive(Clone, Debug, Default)]
 pub struct Point<T: WktFloat>(pub Option<Coord<T>>);

--- a/src/types/polygon.rs
+++ b/src/types/polygon.rs
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::fmt;
-use std::str::FromStr;
 use crate::tokenizer::PeekableTokens;
 use crate::types::linestring::LineString;
 use crate::{FromTokens, Geometry, WktFloat};
+use std::fmt;
+use std::str::FromStr;
 
 #[derive(Clone, Debug, Default)]
 pub struct Polygon<T: WktFloat>(pub Vec<LineString<T>>);


### PR DESCRIPTION
* Made a few changes similar to recent cleanup efforts with the geo repo
* spellchecking
* make clippy happier (there are still a few outstanding ones, todo in a separate PR)
* automatically run CI on PRs, not just push

- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- ~~[ ] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.~~
---

