### PR TITLE
Use geo_types macros to future proof

### DIFF
--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -18,7 +18,7 @@ use Wkt;
 
 use std::convert::{TryFrom, TryInto};
 
-use geo_types::CoordFloat;
+use geo_types::{coord, CoordFloat};
 use thiserror::Error;
 
 #[derive(Error, Debug)]
@@ -90,10 +90,7 @@ where
     T: CoordFloat,
 {
     fn from(coord: Coord<T>) -> geo_types::Coordinate<T> {
-        Self {
-            x: coord.x,
-            y: coord.y,
-        }
+        coord! { x: coord.x, y: coord.y }
     }
 }
 


### PR DESCRIPTION
Use `coord!` macro instead of `geo_types::Coordinate<T> { x, y }`. Doing this makes coordinate creation consistent, and allows more flexibility in the geo_types repo to introduce object changes.

- [ ] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [ ] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

