### PR TITLE
BREAKING: move `Wkt::from_str` to `FromStr` trait

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,8 @@
   * <https://github.com/georust/wkt/pull/72>
 * BREAKING: Reject empty strings instead of parsing them into an empty `Wkt`.
   * <https://github.com/georust/wkt/pull/72>
+* BREAKING: move `Wkt::from_str` to `FromStr` trait. Add `use std::str::FromStr;` to your code to use it.
+  * <https://github.com/georust/wkt/pull/79>
 * Switch to 2021 edition and add examples
   * <https://github.com/georust/wkt/pull/65>
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@
 //! # Examples
 //!
 //! ```
+//! use std::str::FromStr;
 //! use wkt::Wkt;
 //! let point: Wkt<f64> = Wkt::from_str("POINT(10 20)").unwrap();
 //! ```
@@ -43,6 +44,7 @@
 //! If you wish to work directly with one of the WKT [`types`] you can match on the `item` field
 //! ```
 //! use std::convert::TryInto;
+//! use std::str::FromStr;
 //! use wkt::Wkt;
 //! use wkt::Geometry;
 //!
@@ -187,11 +189,6 @@ impl<T> Wkt<T>
 where
     T: WktFloat + FromStr + Default,
 {
-    pub fn from_str(wkt_str: &str) -> Result<Self, &'static str> {
-        let tokens = Tokens::from_str(wkt_str);
-        Wkt::from_tokens(tokens)
-    }
-
     fn from_tokens(tokens: Tokens<T>) -> Result<Self, &'static str> {
         let mut tokens = tokens.peekable();
         let word = match tokens.next() {
@@ -207,6 +204,17 @@ where
             Ok(item) => Ok(Wkt { item }),
             Err(s) => Err(s),
         }
+    }
+}
+
+impl<T> FromStr for Wkt<T>
+where
+    T: WktFloat + FromStr + Default,
+{
+    type Err = &'static str;
+
+    fn from_str(wkt_str: &str) -> Result<Self, Self::Err> {
+        Wkt::from_tokens(Tokens::from_str(wkt_str))
     }
 }
 
@@ -265,6 +273,7 @@ where
 mod tests {
     use crate::types::{Coord, MultiPolygon, Point};
     use crate::{Geometry, Wkt};
+    use std::str::FromStr;
 
     #[test]
     fn empty_string() {

--- a/src/types/geometrycollection.rs
+++ b/src/types/geometrycollection.rs
@@ -85,6 +85,7 @@ mod tests {
     use super::GeometryCollection;
     use crate::types::*;
     use crate::{Geometry, Wkt};
+    use std::str::FromStr;
 
     #[test]
     fn basic_geometrycollection() {

--- a/src/types/linestring.rs
+++ b/src/types/linestring.rs
@@ -64,6 +64,7 @@ where
 mod tests {
     use super::{Coord, LineString};
     use crate::{Geometry, Wkt};
+    use std::str::FromStr;
 
     #[test]
     fn basic_linestring() {

--- a/src/types/multilinestring.rs
+++ b/src/types/multilinestring.rs
@@ -73,6 +73,7 @@ mod tests {
     use super::{LineString, MultiLineString};
     use crate::types::Coord;
     use crate::{Geometry, Wkt};
+    use std::str::FromStr;
 
     #[test]
     fn basic_multilinestring() {

--- a/src/types/multipoint.rs
+++ b/src/types/multipoint.rs
@@ -69,6 +69,7 @@ mod tests {
     use super::{MultiPoint, Point};
     use crate::types::Coord;
     use crate::{Geometry, Wkt};
+    use std::str::FromStr;
 
     #[test]
     fn basic_multipoint() {

--- a/src/types/multipolygon.rs
+++ b/src/types/multipolygon.rs
@@ -78,6 +78,7 @@ mod tests {
     use super::{MultiPolygon, Polygon};
     use crate::types::{Coord, LineString};
     use crate::{Geometry, Wkt};
+    use std::str::FromStr;
 
     #[test]
     fn basic_multipolygon() {

--- a/src/types/point.rs
+++ b/src/types/point.rs
@@ -69,6 +69,7 @@ where
 mod tests {
     use super::{Coord, Point};
     use crate::{Geometry, Wkt};
+    use std::str::FromStr;
 
     #[test]
     fn basic_point() {

--- a/src/types/polygon.rs
+++ b/src/types/polygon.rs
@@ -73,6 +73,7 @@ mod tests {
     use super::{LineString, Polygon};
     use crate::types::Coord;
     use crate::{Geometry, Wkt};
+    use std::str::FromStr;
 
     #[test]
     fn basic_polygon() {


### PR DESCRIPTION
Most of the user's code will stay the same, but will require `use std::str::FromStr;`

See also discussion in #77 

- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

