### PR TITLE
Fix bench build bug, added CI lints

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,10 @@ jobs:
           toolchain: stable
           profile: minimal
           override: true
-          components: rustfmt, rust-src
+          components: rustfmt, clippy, rust-src
       - name: Checkout repository
         uses: actions/checkout@v2
-      - run: cargo test --all-features && cargo test --no-default-features
+      - run: cargo fmt --all -- --check
+      - run: cargo clippy --all-features --all-targets -- -Dwarnings
+      - run: cargo test --all-features
+      - run: cargo test --no-default-features

--- a/benches/parse.rs
+++ b/benches/parse.rs
@@ -2,6 +2,8 @@
 extern crate criterion;
 extern crate wkt;
 
+use std::str::FromStr;
+
 fn criterion_benchmark(c: &mut criterion::Criterion) {
     c.bench_function("parse small", |bencher| {
         let s = include_str!("./small.wkt");


### PR DESCRIPTION
In order to auto-catch bugs and code quality,
adding clippy and fmt to CI (same as geo)

- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- ~[ ] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.~
---

