### PR TITLE
Easier serialization of wkt with ToWkt::wkt_string/write_wkt

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,7 @@
 ### Added
 * impl `std::fmt::Display` for `Wkt`.
   * <https://github.com/georust/wkt/pull/88>
-* added `to_wkt_string` method to `ToWkt`
+* added `wkt_string` and `write_wkt` methods to `ToWkt` trait
   * <https://github.com/georust/wkt/pull/89>
 
 ## 0.10.0 - 2022-02-24

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,8 +1,12 @@
 # Changes
 
 ## next release
-### Changed
+
+### Added
 * impl `std::fmt::Display` for `Wkt`.
+  * <https://github.com/georust/wkt/pull/88>
+* added `to_wkt_string` method to `ToWkt`
+  * <https://github.com/georust/wkt/pull/89>
 
 ## 0.10.0 - 2022-02-24
 ### Changed

--- a/src/towkt.rs
+++ b/src/towkt.rs
@@ -10,10 +10,21 @@ use geo_types::CoordFloat;
 /// A trait for converting values to WKT
 pub trait ToWkt<T>
 where
-    T: CoordFloat,
+    T: CoordFloat + std::fmt::Display,
 {
     /// Converts the value of `self` to an instance of WKT
     fn to_wkt(&self) -> Wkt<T>;
+
+    /// Serialize as a WKT string
+    ///
+    /// ```
+    /// use wkt::ToWkt;
+    /// let point: geo_types::Geometry<f64> = geo_types::point!(x: 1.0, y: 2.0).into();
+    /// assert_eq!("POINT(1 2)", &point.to_wkt_string());
+    /// ```
+    fn to_wkt_string(&self) -> String {
+        self.to_wkt().to_string()
+    }
 }
 
 fn g_point_to_w_coord<T>(g_point: &geo_types::Coordinate<T>) -> Coord<T>
@@ -215,7 +226,7 @@ where
 
 impl<T> ToWkt<T> for geo_types::Geometry<T>
 where
-    T: CoordFloat,
+    T: CoordFloat + std::fmt::Display,
 {
     fn to_wkt(&self) -> Wkt<T> {
         let w_geom = g_geom_to_w_geom(self);

--- a/src/towkt.rs
+++ b/src/towkt.rs
@@ -12,7 +12,10 @@ pub trait ToWkt<T>
 where
     T: CoordFloat + std::fmt::Display,
 {
-    /// Converts the value of `self` to an instance of WKT
+    /// Converts the value of `self` to an [`Wkt`] struct.
+    ///
+    /// Typically you won't need to call this, but by implementing it for your own type, your type
+    /// gains the other methods in this trait.
     fn to_wkt(&self) -> Wkt<T>;
 
     /// Serialize as a WKT string
@@ -20,10 +23,31 @@ where
     /// ```
     /// use wkt::ToWkt;
     /// let point: geo_types::Geometry<f64> = geo_types::point!(x: 1.0, y: 2.0).into();
-    /// assert_eq!("POINT(1 2)", &point.to_wkt_string());
+    /// assert_eq!("POINT(1 2)", &point.wkt_string());
     /// ```
-    fn to_wkt_string(&self) -> String {
+    fn wkt_string(&self) -> String {
         self.to_wkt().to_string()
+    }
+
+    /// Write a WKT string to a [`File`](std::fs::File), or anything else that implements [`Write`](std::io::Write).
+    ///
+    /// ```
+    /// use wkt::ToWkt;
+    /// use std::fs::File;
+    /// let point: geo_types::Geometry<f64> = geo_types::point!(x: 1.2, y: 3.4).into();
+    ///
+    /// // use a vec as a fake "file" for the purpose of example, but you could equally replace the
+    /// // following with:
+    /// //     let mut file = File::create("myfile.wkt").unwrap();
+    /// let mut file = vec![] ;
+    ///
+    /// point.write_wkt(&mut file).unwrap();
+    /// let wkt_string = String::from_utf8(file).unwrap();
+    ///
+    /// assert_eq!(wkt_string, "POINT(1.2 3.4)");
+    /// ```
+    fn write_wkt(&self, mut writer: impl std::io::Write) -> std::io::Result<()> {
+        writer.write_all(self.wkt_string().as_bytes())
     }
 }
 


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
- [x] I ran cargo fmt
---
Fixes #55 - adds an easier API to serialize a geo-type.

~~Depends on #86, so merge that first.~~ Merged!

~~partially conflicts with #88, because I'm relying on the `ToWkt` trait.~~ superseded!
