### PR TITLE
FromWkt trait for reading WKT without exposing the user to the intermediate representation.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,7 +16,8 @@
 * New `FromWkt` trait allows a way to convert from a string or reader directly
   to geo-types, without exposing you to the intermediate `Wkt` structs.
     * <https://github.com/georust/wkt/pull/95>
-
+* Implemented `geo_types::GeometryCollection::from(Wkt::from_str(wkt_str))`
+    * <https://github.com/georust/wkt/pull/95>
 
 ## 0.10.0 - 2022-02-24
 ### Changed

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,13 +5,18 @@
 ### Added
 * impl `std::fmt::Display` for `Wkt`.
   * <https://github.com/georust/wkt/pull/88>
-* added `wkt_string` and `write_wkt` methods to `ToWkt` trait
-  * <https://github.com/georust/wkt/pull/89>
-* impl `ToWkt` on geo_type Geometry variants directly, so you can `point!(x: 1., y: 2.).wkt_string()`
-  * <https://github.com/georust/wkt/pull/90>
-* `ToWkt` is no longer tied to geo-types. You can implement it on your own
-  custom (non-geo_type) geometry types.
-  * <https://github.com/georust/wkt/pull/90>
+* Additions to ToWkt trait:
+  * added `wkt_string` and `write_wkt` methods to `ToWkt` trait
+    * <https://github.com/georust/wkt/pull/89>
+  * impl `ToWkt` on geo_type Geometry variants directly, so you can `point!(x: 1., y: 2.).wkt_string()`
+    * <https://github.com/georust/wkt/pull/90>
+  * `ToWkt` is no longer tied to geo-types. You can implement it on your own
+    custom (non-geo_type) geometry types.
+    * <https://github.com/georust/wkt/pull/90>
+* New `FromWkt` trait allows a way to convert from a string or reader directly
+  to geo-types, without exposing you to the intermediate `Wkt` structs.
+    * <https://github.com/georust/wkt/pull/95>
+
 
 ## 0.10.0 - 2022-02-24
 ### Changed

--- a/benches/parse.rs
+++ b/benches/parse.rs
@@ -3,6 +3,7 @@ extern crate criterion;
 extern crate wkt;
 
 use std::str::FromStr;
+use wkt::TryFromWkt;
 
 fn bench_parse(c: &mut criterion::Criterion) {
     c.bench_function("parse small", |bencher| {
@@ -24,14 +25,14 @@ fn bench_parse_to_geo(c: &mut criterion::Criterion) {
     c.bench_function("parse small to geo", |bencher| {
         let s = include_str!("./small.wkt");
         bencher.iter(|| {
-            let _ = geo_types::Geometry::try_from(wkt::Wkt::<f64>::from_str(s).unwrap());
+            let _ = geo_types::Geometry::<f64>::try_from_wkt_str(s).unwrap();
         });
     });
 
     c.bench_function("parse big to geo", |bencher| {
         let s = include_str!("./big.wkt");
         bencher.iter(|| {
-            let _ = geo_types::Geometry::try_from(wkt::Wkt::<f64>::from_str(s).unwrap());
+            let _ = geo_types::Geometry::<f64>::try_from_wkt_str(s).unwrap();
         });
     });
 }

--- a/src/from_wkt.rs
+++ b/src/from_wkt.rs
@@ -1,0 +1,31 @@
+/// Create geometries from WKT.
+///
+/// A default implementation exists for [geo-types](../geo-types), or you can implement this trait
+/// for your own types.
+pub trait TryFromWkt<T>: Sized {
+    type Error;
+
+    /// # Examples
+    #[cfg_attr(feature = "geo-types", doc = "```")]
+    #[cfg_attr(not(feature = "geo-types"), doc = "```ignore")]
+    /// // This example requires the geo-types feature (on by default).
+    /// use wkt::TryFromWkt;
+    /// use geo_types::Point;
+    /// let point: Point<f64> = Point::try_from_wkt_str("POINT(10 20)").unwrap();
+    /// assert_eq!(point.y(), 20.0);
+    /// ```
+    fn try_from_wkt_str(wkt_str: &str) -> Result<Self, Self::Error>;
+
+    /// # Examples
+    #[cfg_attr(feature = "geo-types", doc = "```")]
+    #[cfg_attr(not(feature = "geo-types"), doc = "```ignore")]
+    /// // This example requires the geo-types feature (on by default).
+    /// use wkt::TryFromWkt;
+    /// use geo_types::Point;
+    ///
+    /// let fake_file = "POINT(10 20)".as_bytes().to_vec();
+    /// let point: Point<f64> = Point::try_from_wkt_reader(&*fake_file).unwrap();
+    /// assert_eq!(point.y(), 20.0);
+    /// ```
+    fn try_from_wkt_reader(wkt_reader: impl std::io::Read) -> Result<Self, Self::Error>;
+}


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
- [x] I ran cargo fmt
---

Draft because it's based on #94. Please review that first.

--- 

Note that this isn't a performance change. It's about (hopefully) making
the library easier to use.

This is a corollary to https://github.com/georust/wkt/pull/89, but for
reading WKT, rather than writing. As we discussed there, probably there
is no reason for the user to care about the Wkt struct.

Note that the intermediate representation is still used (for now!), but
the user is no longer required to interact with it.

The road is open though for having a direct translation from Wkt text to
the geo-types (or whatever) represenation (see geozero for inspiration).

--- 

I also added the missing GeometryCollection::from(wkt) implementation to make this work for all geo-types.