### PR TITLE
Use SPDX license expression

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Changes
 
+## Unreleased
+
+* Changed license field to [SPDX 2.1 license expression](https://spdx.dev/spdx-specification-21-web-version/#h.jxpfx0ykyb60)
+
 ## 0.10.3 - 2022-06-22
 
 * Fixed a typo in the release notes to reference the correct version

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "wkt"
 description = "Rust read/write support for well-known text (WKT)"
 version = "0.10.3"
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 repository = "https://github.com/georust/wkt"
 autobenches = true
 readme = "README.md"


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
- [x] I ran cargo fmt
---

Uses a SPDX license expression as recommended by [Cargo](https://doc.rust-lang.org/cargo/reference/manifest.html#the-license-and-license-file-fields).

This enables e.g. parsing via the [CycloneDX Rust Cargo Plugin](https://github.com/CycloneDX/cyclonedx-rust-cargo).