### PR TITLE
prepare for v0.11.0 release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,13 +1,13 @@
 # Changes
 
-## Unreleased
+## 0.11.0 - 2024-07-24
 
 * Support parsing Z, M, and ZM WKT strings.
 * Changed license field to [SPDX 2.1 license expression](https://spdx.dev/spdx-specification-21-web-version/#h.jxpfx0ykyb60)
 * Bump min version of geo-types, and update geo_types::Coordinate to non-deprecated geo_types::Coord
 * BREAKING: WktNum must implement PartialEq
 * Implement PartialEq for Wkt
-* BREAKING: Simplify Wkt data structure by replacing it with it's only field (formerly known as `item: Geometry`)
+* BREAKING: Simplify Wkt data structure by replacing it with its only field (formerly known as `item: Geometry`)
 * BREAKING: Replace geometry_variant.as_item() with Wkt::from(geometry_variant)
 
 ## 0.10.3 - 2022-06-22

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wkt"
 description = "Rust read/write support for well-known text (WKT)"
-version = "0.10.3"
+version = "0.11.0"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/georust/wkt"
 autobenches = true


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
- [x] I ran cargo fmt
---

I'll plan on releasing this tomorrow unless I hear otherwise.