### PR TITLE
include "write" bench in cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,10 @@ default = ["geo-types"]
 name = "parse"
 harness = false
 
+[[bench]]
+name = "write"
+harness = false
+
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [n/a] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
- [x] I ran cargo fmt
---

I included a write benchmark a while ago, but apparently never added it to Cargo.toml 😅
