### PR TITLE
Implement geo-traits for writing to WKT & perf improvement

### DIFF
--- a/benches/write.rs
+++ b/benches/write.rs
@@ -70,7 +70,7 @@ fn geo_write_wkt_as_trait(c: &mut criterion::Criterion) {
         let w = wkt::Wkt::<f64>::from_str(s).unwrap();
         let g = geo_types::Geometry::try_from(w).unwrap();
         bencher.iter(|| {
-            wkt::to_wkt::geo_trait_impl::write_geometry(&g, &mut String::new()).unwrap();
+            wkt::to_wkt::write_geometry(&g, &mut String::new()).unwrap();
         });
     });
 
@@ -79,7 +79,7 @@ fn geo_write_wkt_as_trait(c: &mut criterion::Criterion) {
         let w = wkt::Wkt::<f64>::from_str(s).unwrap();
         let g = geo_types::Geometry::try_from(w).unwrap();
         bencher.iter(|| {
-            wkt::to_wkt::geo_trait_impl::write_geometry(&g, &mut String::new()).unwrap();
+            wkt::to_wkt::write_geometry(&g, &mut String::new()).unwrap();
         });
     });
 }

--- a/benches/write.rs
+++ b/benches/write.rs
@@ -64,5 +64,31 @@ fn geo_write_wkt(c: &mut criterion::Criterion) {
     });
 }
 
-criterion_group!(benches, wkt_to_string, geo_to_wkt_string, geo_write_wkt);
+fn geo_write_wkt_as_trait(c: &mut criterion::Criterion) {
+    c.bench_function("geo: write small wkt using trait", |bencher| {
+        let s = include_str!("./small.wkt");
+        let w = wkt::Wkt::<f64>::from_str(s).unwrap();
+        let g = geo_types::Geometry::try_from(w).unwrap();
+        bencher.iter(|| {
+            wkt::to_wkt::geo_trait_impl::geometry_to_wkt(&g, &mut String::new()).unwrap();
+        });
+    });
+
+    c.bench_function("geo: write big wkt using trait", |bencher| {
+        let s = include_str!("./big.wkt");
+        let w = wkt::Wkt::<f64>::from_str(s).unwrap();
+        let g = geo_types::Geometry::try_from(w).unwrap();
+        bencher.iter(|| {
+            wkt::to_wkt::geo_trait_impl::geometry_to_wkt(&g, &mut String::new()).unwrap();
+        });
+    });
+}
+
+criterion_group!(
+    benches,
+    wkt_to_string,
+    geo_to_wkt_string,
+    geo_write_wkt,
+    geo_write_wkt_as_trait
+);
 criterion_main!(benches);

--- a/benches/write.rs
+++ b/benches/write.rs
@@ -70,7 +70,7 @@ fn geo_write_wkt_as_trait(c: &mut criterion::Criterion) {
         let w = wkt::Wkt::<f64>::from_str(s).unwrap();
         let g = geo_types::Geometry::try_from(w).unwrap();
         bencher.iter(|| {
-            wkt::to_wkt::geo_trait_impl::geometry_to_wkt(&g, &mut String::new()).unwrap();
+            wkt::to_wkt::geo_trait_impl::write_geometry(&g, &mut String::new()).unwrap();
         });
     });
 
@@ -79,7 +79,7 @@ fn geo_write_wkt_as_trait(c: &mut criterion::Criterion) {
         let w = wkt::Wkt::<f64>::from_str(s).unwrap();
         let g = geo_types::Geometry::try_from(w).unwrap();
         bencher.iter(|| {
-            wkt::to_wkt::geo_trait_impl::geometry_to_wkt(&g, &mut String::new()).unwrap();
+            wkt::to_wkt::geo_trait_impl::write_geometry(&g, &mut String::new()).unwrap();
         });
     });
 }

--- a/benches/write.rs
+++ b/benches/write.rs
@@ -70,7 +70,7 @@ fn geo_write_wkt_as_trait(c: &mut criterion::Criterion) {
         let w = wkt::Wkt::<f64>::from_str(s).unwrap();
         let g = geo_types::Geometry::try_from(w).unwrap();
         bencher.iter(|| {
-            wkt::to_wkt::write_geometry(&g, &mut String::new()).unwrap();
+            wkt::to_wkt::write_geometry(&mut String::new(), &g).unwrap();
         });
     });
 
@@ -79,7 +79,7 @@ fn geo_write_wkt_as_trait(c: &mut criterion::Criterion) {
         let w = wkt::Wkt::<f64>::from_str(s).unwrap();
         let g = geo_types::Geometry::try_from(w).unwrap();
         bencher.iter(|| {
-            wkt::to_wkt::write_geometry(&g, &mut String::new()).unwrap();
+            wkt::to_wkt::write_geometry(&mut String::new(), &g).unwrap();
         });
     });
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -11,14 +11,14 @@ pub enum Error {
     UnknownDimension,
     /// Wrapper around `[std::fmt::Error]`
     #[error(transparent)]
-    FmtError(#[from] std::fmt::Error),
+    FmtError(#[from] core::fmt::Error),
 }
 
 impl From<Error> for fmt::Error {
     fn from(value: Error) -> Self {
         match value {
             Error::FmtError(err) => err,
-            _ => std::fmt::Error,
+            _ => core::fmt::Error,
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,8 +2,8 @@ use core::fmt;
 
 use thiserror::Error;
 
+/// Generic errors for WKT writing and reading
 #[derive(Error, Debug)]
-/// WKT to [`geo_types`] conversions errors
 pub enum Error {
     #[error("Only 2D input is supported when writing Rect to WKT.")]
     RectUnsupportedDimension,

--- a/src/error.rs
+++ b/src/error.rs
@@ -5,8 +5,8 @@ use thiserror::Error;
 #[derive(Error, Debug)]
 /// WKT to [`geo_types`] conversions errors
 pub enum Error {
-    // #[error("The WKT Point was empty, but geo_type::Points cannot be empty")]
-    // RectWriter,
+    #[error("Only 2D input is supported when writing Rect to WKT.")]
+    RectUnsupportedDimension,
     #[error("Only defined dimensions and undefined dimensions of 2, 3, or 4 are supported.")]
     UnknownDimension,
     /// Wrapper around `[std::fmt::Error]`

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,4 @@
-use core::fmt;
+use std::fmt;
 
 use thiserror::Error;
 
@@ -11,14 +11,14 @@ pub enum Error {
     UnknownDimension,
     /// Wrapper around `[std::fmt::Error]`
     #[error(transparent)]
-    FmtError(#[from] core::fmt::Error),
+    FmtError(#[from] std::fmt::Error),
 }
 
 impl From<Error> for fmt::Error {
     fn from(value: Error) -> Self {
         match value {
             Error::FmtError(err) => err,
-            _ => core::fmt::Error,
+            _ => std::fmt::Error,
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,24 @@
+use core::fmt;
+
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+/// WKT to [`geo_types`] conversions errors
+pub enum Error {
+    // #[error("The WKT Point was empty, but geo_type::Points cannot be empty")]
+    // RectWriter,
+    #[error("Only defined dimensions and undefined dimensions of 2, 3, or 4 are supported.")]
+    UnknownDimension,
+    /// Wrapper around `[std::fmt::Error]`
+    #[error(transparent)]
+    FmtError(#[from] std::fmt::Error),
+}
+
+impl From<Error> for fmt::Error {
+    fn from(value: Error) -> Self {
+        match value {
+            Error::FmtError(err) => err,
+            _ => std::fmt::Error,
+        }
+    }
+}

--- a/src/geo_traits_to_wkt.rs
+++ b/src/geo_traits_to_wkt.rs
@@ -1,3 +1,0 @@
-use geo_traits::GeometryTrait;
-
-// pub fn to_wkt(g: &impl GeometryTrait) ->

--- a/src/geo_traits_to_wkt.rs
+++ b/src/geo_traits_to_wkt.rs
@@ -1,0 +1,3 @@
+use geo_traits::GeometryTrait;
+
+// pub fn to_wkt(g: &impl GeometryTrait) ->

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,7 +93,7 @@ use crate::types::{
     Polygon,
 };
 
-mod to_wkt;
+pub mod to_wkt;
 mod tokenizer;
 
 /// `WKT` primitive types and collections

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -360,7 +360,7 @@ where
     T: WktNum + fmt::Display,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        Ok(write_geometry(self, f)?)
+        Ok(write_geometry(f, self)?)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,6 +86,7 @@ use geo_traits::{
 };
 use num_traits::{Float, Num, NumCast};
 
+use crate::to_wkt::geo_trait_impl::geometry_to_wkt;
 use crate::tokenizer::{PeekableTokens, Token, Tokens};
 use crate::types::{
     Dimension, GeometryCollection, LineString, MultiLineString, MultiPoint, MultiPolygon, Point,
@@ -112,7 +113,6 @@ pub use crate::to_wkt::ToWkt;
 #[cfg(feature = "geo-types")]
 #[deprecated(note = "renamed module to `wkt::geo_types_from_wkt`")]
 pub mod conversion;
-pub mod geo_traits_to_wkt;
 #[cfg(feature = "geo-types")]
 pub mod geo_types_from_wkt;
 #[cfg(feature = "geo-types")]
@@ -360,15 +360,7 @@ where
     T: WktNum + fmt::Display,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        match self {
-            Wkt::Point(point) => point.fmt(f),
-            Wkt::LineString(linestring) => linestring.fmt(f),
-            Wkt::Polygon(polygon) => polygon.fmt(f),
-            Wkt::MultiPoint(multipoint) => multipoint.fmt(f),
-            Wkt::MultiLineString(multilinstring) => multilinstring.fmt(f),
-            Wkt::MultiPolygon(multipolygon) => multipolygon.fmt(f),
-            Wkt::GeometryCollection(geometrycollection) => geometrycollection.fmt(f),
-        }
+        geometry_to_wkt(self, f)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,7 +86,7 @@ use geo_traits::{
 };
 use num_traits::{Float, Num, NumCast};
 
-use crate::to_wkt::geo_trait_impl::write_geometry;
+use crate::to_wkt::write_geometry;
 use crate::tokenizer::{PeekableTokens, Token, Tokens};
 use crate::types::{
     Dimension, GeometryCollection, LineString, MultiLineString, MultiPoint, MultiPolygon, Point,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,7 +86,7 @@ use geo_traits::{
 };
 use num_traits::{Float, Num, NumCast};
 
-use crate::to_wkt::geo_trait_impl::geometry_to_wkt;
+use crate::to_wkt::geo_trait_impl::write_geometry;
 use crate::tokenizer::{PeekableTokens, Token, Tokens};
 use crate::types::{
     Dimension, GeometryCollection, LineString, MultiLineString, MultiPoint, MultiPolygon, Point,
@@ -360,7 +360,7 @@ where
     T: WktNum + fmt::Display,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        geometry_to_wkt(self, f)
+        write_geometry(self, f)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,6 +96,8 @@ use crate::types::{
 pub mod to_wkt;
 mod tokenizer;
 
+/// Error variant for this crate
+pub mod error;
 /// `WKT` primitive types and collections
 pub mod types;
 
@@ -105,8 +107,6 @@ pub use infer_type::infer_type;
 
 #[cfg(feature = "geo-types")]
 extern crate geo_types;
-
-extern crate thiserror;
 
 pub use crate::to_wkt::ToWkt;
 
@@ -360,7 +360,7 @@ where
     T: WktNum + fmt::Display,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        write_geometry(self, f)
+        Ok(write_geometry(self, f)?)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,6 +112,7 @@ pub use crate::to_wkt::ToWkt;
 #[cfg(feature = "geo-types")]
 #[deprecated(note = "renamed module to `wkt::geo_types_from_wkt`")]
 pub mod conversion;
+pub mod geo_traits_to_wkt;
 #[cfg(feature = "geo-types")]
 pub mod geo_types_from_wkt;
 #[cfg(feature = "geo-types")]

--- a/src/to_wkt/geo_trait_impl.rs
+++ b/src/to_wkt/geo_trait_impl.rs
@@ -33,9 +33,9 @@ impl From<geo_traits::Dimensions> for PhysicalCoordinateDimension {
     }
 }
 
-pub fn write_point<T: WktNum + fmt::Display, G: PointTrait<T = T>, W: Write>(
+pub fn write_point<T: WktNum + fmt::Display, G: PointTrait<T = T>>(
     g: &G,
-    f: &mut W,
+    f: &mut impl Write,
 ) -> Result<(), Error> {
     let dim = g.dim();
     // Write prefix
@@ -59,9 +59,9 @@ pub fn write_point<T: WktNum + fmt::Display, G: PointTrait<T = T>, W: Write>(
     }
 }
 
-pub fn write_linestring<T: WktNum + fmt::Display, G: LineStringTrait<T = T>, W: Write>(
+pub fn write_linestring<T: WktNum + fmt::Display, G: LineStringTrait<T = T>>(
     linestring: &G,
-    f: &mut W,
+    f: &mut impl Write,
 ) -> Result<(), Error> {
     let dim = linestring.dim();
     // Write prefix
@@ -86,9 +86,9 @@ pub fn write_linestring<T: WktNum + fmt::Display, G: LineStringTrait<T = T>, W: 
     }
 }
 
-pub fn write_polygon<T: WktNum + fmt::Display, G: PolygonTrait<T = T>, W: Write>(
+pub fn write_polygon<T: WktNum + fmt::Display, G: PolygonTrait<T = T>>(
     polygon: &G,
-    f: &mut W,
+    f: &mut impl Write,
 ) -> Result<(), Error> {
     let dim = polygon.dim();
     // Write prefix
@@ -123,9 +123,9 @@ pub fn write_polygon<T: WktNum + fmt::Display, G: PolygonTrait<T = T>, W: Write>
     }
 }
 
-pub fn write_multi_point<T: WktNum + fmt::Display, G: MultiPointTrait<T = T>, W: Write>(
+pub fn write_multi_point<T: WktNum + fmt::Display, G: MultiPointTrait<T = T>>(
     multipoint: &G,
-    f: &mut W,
+    f: &mut impl Write,
 ) -> Result<(), Error> {
     let dim = multipoint.dim();
     // Write prefix
@@ -167,13 +167,9 @@ pub fn write_multi_point<T: WktNum + fmt::Display, G: MultiPointTrait<T = T>, W:
     Ok(())
 }
 
-pub fn write_multi_linestring<
-    T: WktNum + fmt::Display,
-    G: MultiLineStringTrait<T = T>,
-    W: Write,
->(
+pub fn write_multi_linestring<T: WktNum + fmt::Display, G: MultiLineStringTrait<T = T>>(
     multilinestring: &G,
-    f: &mut W,
+    f: &mut impl Write,
 ) -> Result<(), Error> {
     let dim = multilinestring.dim();
     // Write prefix
@@ -209,9 +205,9 @@ pub fn write_multi_linestring<
     Ok(())
 }
 
-pub fn write_multi_polygon<T: WktNum + fmt::Display, G: MultiPolygonTrait<T = T>, W: Write>(
+pub fn write_multi_polygon<T: WktNum + fmt::Display, G: MultiPolygonTrait<T = T>>(
     multipolygon: &G,
-    f: &mut W,
+    f: &mut impl Write,
 ) -> Result<(), Error> {
     let dim = multipolygon.dim();
     // Write prefix
@@ -261,9 +257,9 @@ pub fn write_multi_polygon<T: WktNum + fmt::Display, G: MultiPolygonTrait<T = T>
 
 /// Create geometry to WKT representation.
 
-pub fn write_geometry<T: WktNum + fmt::Display, G: GeometryTrait<T = T>, W: Write>(
+pub fn write_geometry<T: WktNum + fmt::Display, G: GeometryTrait<T = T>>(
     geometry: &G,
-    f: &mut W,
+    f: &mut impl Write,
 ) -> Result<(), Error> {
     match geometry.as_type() {
         geo_traits::GeometryType::Point(point) => write_point(point, f),
@@ -281,13 +277,9 @@ pub fn write_geometry<T: WktNum + fmt::Display, G: GeometryTrait<T = T>, W: Writ
     }
 }
 
-pub fn write_geometry_collection<
-    T: WktNum + fmt::Display,
-    G: GeometryCollectionTrait<T = T>,
-    W: Write,
->(
+pub fn write_geometry_collection<T: WktNum + fmt::Display, G: GeometryCollectionTrait<T = T>>(
     gc: &G,
-    f: &mut W,
+    f: &mut impl Write,
 ) -> Result<(), Error> {
     let dim = gc.dim();
     // Write prefix
@@ -322,9 +314,9 @@ pub fn write_geometry_collection<
     Ok(())
 }
 
-pub fn write_rect<T: WktNum + fmt::Display, G: RectTrait<T = T>, W: Write>(
+pub fn write_rect<T: WktNum + fmt::Display, G: RectTrait<T = T>>(
     rect: &G,
-    f: &mut W,
+    f: &mut impl Write,
 ) -> Result<(), Error> {
     // Write prefix and error if not 2D
     match rect.dim() {
@@ -374,9 +366,9 @@ pub fn write_rect<T: WktNum + fmt::Display, G: RectTrait<T = T>, W: Write>(
     Ok(f.write_char(')')?)
 }
 
-pub fn write_triangle<T: WktNum + fmt::Display, G: TriangleTrait<T = T>, W: Write>(
+pub fn write_triangle<T: WktNum + fmt::Display, G: TriangleTrait<T = T>>(
     triangle: &G,
-    f: &mut W,
+    f: &mut impl Write,
 ) -> Result<(), Error> {
     let dim = triangle.dim();
     // Write prefix
@@ -403,9 +395,9 @@ pub fn write_triangle<T: WktNum + fmt::Display, G: TriangleTrait<T = T>, W: Writ
     Ok(f.write_char(')')?)
 }
 
-pub fn write_line<T: WktNum + fmt::Display, G: LineTrait<T = T>, W: Write>(
+pub fn write_line<T: WktNum + fmt::Display, G: LineTrait<T = T>>(
     line: &G,
-    f: &mut W,
+    f: &mut impl Write,
 ) -> Result<(), Error> {
     let dim = line.dim();
     // Write prefix
@@ -429,9 +421,9 @@ pub fn write_line<T: WktNum + fmt::Display, G: LineTrait<T = T>, W: Write>(
 /// Write a single coordinate to the writer.
 ///
 /// Will not include any start or end `()` characters.
-fn write_coord<T: WktNum + fmt::Display, G: CoordTrait<T = T>, W: Write>(
+fn write_coord<T: WktNum + fmt::Display, G: CoordTrait<T = T>>(
     coord: &G,
-    f: &mut W,
+    f: &mut impl Write,
     size: PhysicalCoordinateDimension,
 ) -> Result<(), std::fmt::Error> {
     match size {
@@ -467,9 +459,9 @@ fn write_coord<T: WktNum + fmt::Display, G: CoordTrait<T = T>, W: Write>(
 /// (1 2, 3 4, 5 6)
 /// ```
 /// for a coordinate sequence with three coordinates.
-fn write_coord_sequence<T: WktNum + fmt::Display, W: Write, C: CoordTrait<T = T>>(
+fn write_coord_sequence<T: WktNum + fmt::Display, C: CoordTrait<T = T>>(
     mut coords: impl Iterator<Item = C>,
-    f: &mut W,
+    f: &mut impl Write,
     size: PhysicalCoordinateDimension,
 ) -> Result<(), Error> {
     f.write_char('(')?;

--- a/src/to_wkt/geo_trait_impl.rs
+++ b/src/to_wkt/geo_trait_impl.rs
@@ -96,7 +96,7 @@ pub fn polygon_to_wkt<T: CoordNum + WktNum + fmt::Display, G: PolygonTrait<T = T
     let size = PhysicalCoordinateDimension::from(dim);
     if let Some(exterior) = polygon.exterior() {
         if exterior.num_coords() != 0 {
-            f.write_str(" (")?;
+            f.write_str("(")?;
             add_coord_sequence(exterior.coords(), f, size)?;
 
             for interior in polygon.interiors() {
@@ -137,17 +137,17 @@ pub fn multi_point_to_wkt<
     // Note: This is largely copied from `add_coord_sequence`, because `multipoint.points()`
     // yields a sequence of Point, not Coord.
     if let Some(first_point) = points.next() {
-        f.write_char('(')?;
+        f.write_str("((")?;
 
         // Assume no empty points within this MultiPoint
         add_coord(&first_point.coord().unwrap(), f, size)?;
 
         for point in points {
-            f.write_char(',')?;
+            f.write_str("),(")?;
             add_coord(&point.coord().unwrap(), f, size)?;
         }
 
-        f.write_char(')')?;
+        f.write_str("))")?;
     } else {
         f.write_str(" EMPTY")?;
     }
@@ -202,10 +202,10 @@ pub fn multi_polygon_to_wkt<
     let dim = multipolygon.dim();
     // Write prefix
     match dim {
-        geo_traits::Dimensions::Xy => f.write_str("MULTILINESTRING"),
-        geo_traits::Dimensions::Xyz => f.write_str("MULTILINESTRING Z"),
-        geo_traits::Dimensions::Xym => f.write_str("MULTILINESTRING M"),
-        geo_traits::Dimensions::Xyzm => f.write_str("MULTILINESTRING ZM"),
+        geo_traits::Dimensions::Xy => f.write_str("MULTIPOLYGON"),
+        geo_traits::Dimensions::Xyz => f.write_str("MULTIPOLYGON Z"),
+        geo_traits::Dimensions::Xym => f.write_str("MULTIPOLYGON M"),
+        geo_traits::Dimensions::Xyzm => f.write_str("MULTIPOLYGON ZM"),
         geo_traits::Dimensions::Unknown(_) => todo!(),
     }?;
     let size = PhysicalCoordinateDimension::from(dim);
@@ -213,7 +213,7 @@ pub fn multi_polygon_to_wkt<
     let mut polygons = multipolygon.polygons();
 
     if let Some(first_polygon) = polygons.next() {
-        f.write_str(" ((")?;
+        f.write_str("((")?;
 
         add_coord_sequence(first_polygon.exterior().unwrap().coords(), f, size)?;
         for interior in first_polygon.interiors() {
@@ -281,7 +281,7 @@ pub fn geometry_collection_to_wkt<
     let mut geometries = gc.geometries();
 
     if let Some(first_geometry) = geometries.next() {
-        f.write_str(" (")?;
+        f.write_str("(")?;
 
         geometry_to_wkt(&first_geometry, f)?;
         for geom in geometries {

--- a/src/to_wkt/geo_trait_impl.rs
+++ b/src/to_wkt/geo_trait_impl.rs
@@ -1,0 +1,326 @@
+use core::fmt;
+use std::fmt::Write;
+
+use geo_traits::{
+    CoordTrait, LineStringTrait, MultiLineStringTrait, MultiPointTrait, MultiPolygonTrait,
+    PointTrait, PolygonTrait,
+};
+use geo_types::CoordNum;
+
+use crate::WktNum;
+
+pub fn coord_to_wkt<T: CoordNum + WktNum + fmt::Display, G: CoordTrait<T = T>, W: Write>(
+    g: &G,
+    f: &mut W,
+) -> Result<(), std::fmt::Error> {
+    match g.dim() {
+        geo_traits::Dimensions::Xy => {
+            write!(f, "{} {}", g.x(), g.y())?;
+        }
+        geo_traits::Dimensions::Xyz | geo_traits::Dimensions::Xym => {
+            write!(f, "{} {} {}", g.x(), g.y(), g.nth_unchecked(2))?;
+        }
+        geo_traits::Dimensions::Xyzm => {
+            write!(
+                f,
+                "{} {} {} {}",
+                g.x(),
+                g.y(),
+                g.nth_unchecked(2),
+                g.nth_unchecked(3)
+            )?;
+        }
+        geo_traits::Dimensions::Unknown(_) => todo!(),
+    };
+
+    Ok(())
+}
+
+pub fn point_to_wkt<T: CoordNum + WktNum + fmt::Display, G: PointTrait<T = T>, W: Write>(
+    g: &G,
+    f: &mut W,
+) -> Result<(), std::fmt::Error> {
+    let dim = g.dim();
+    // Write prefix
+    match dim {
+        geo_traits::Dimensions::Xy => f.write_str("POINT"),
+        geo_traits::Dimensions::Xyz => f.write_str("POINT Z"),
+        geo_traits::Dimensions::Xym => f.write_str("POINT M"),
+        geo_traits::Dimensions::Xyzm => f.write_str("POINT ZM"),
+        geo_traits::Dimensions::Unknown(_) => todo!(),
+    }?;
+    if let Some(coord) = g.coord() {
+        f.write_char('(')?;
+        coord_to_wkt(&coord, f)?;
+        f.write_char(')')?;
+        Ok(())
+    } else {
+        f.write_str(" EMPTY")
+    }
+}
+
+pub fn linestring_to_wkt<
+    T: CoordNum + WktNum + fmt::Display,
+    G: LineStringTrait<T = T>,
+    W: Write,
+>(
+    g: &G,
+    f: &mut W,
+) -> Result<(), std::fmt::Error> {
+    let dim = g.dim();
+    // Write prefix
+    match dim {
+        geo_traits::Dimensions::Xy => f.write_str("LINESTRING"),
+        geo_traits::Dimensions::Xyz => f.write_str("LINESTRING Z"),
+        geo_traits::Dimensions::Xym => f.write_str("LINESTRING M"),
+        geo_traits::Dimensions::Xyzm => f.write_str("LINESTRING ZM"),
+        geo_traits::Dimensions::Unknown(_) => todo!(),
+    }?;
+    if g.num_coords() == 0 {
+        f.write_str(" EMPTY")
+    } else {
+        // add_coords(linestring.coords(), f)?;
+        let strings = g
+            .coords()
+            .map(|c| {
+                let mut s = String::new();
+                coord_to_wkt(&c, &mut s)?;
+                Ok(s)
+            })
+            .collect::<Result<Vec<_>, std::fmt::Error>>()?
+            .join(",");
+        write!(f, "({})", strings)
+    }
+}
+
+pub fn polygon_to_wkt<T: CoordNum + WktNum + fmt::Display, G: PolygonTrait<T = T>, W: Write>(
+    g: &G,
+    f: &mut W,
+) -> Result<(), std::fmt::Error> {
+    let dim = g.dim();
+    // Write prefix
+    match dim {
+        geo_traits::Dimensions::Xy => f.write_str("POLYGON"),
+        geo_traits::Dimensions::Xyz => f.write_str("POLYGON Z"),
+        geo_traits::Dimensions::Xym => f.write_str("POLYGON M"),
+        geo_traits::Dimensions::Xyzm => f.write_str("POLYGON ZM"),
+        geo_traits::Dimensions::Unknown(_) => todo!(),
+    }?;
+    if let Some(exterior) = g.exterior() {
+        let exterior_string = exterior
+            .coords()
+            .map(|c| {
+                let mut s = String::new();
+                coord_to_wkt(&c, &mut s)?;
+                Ok(s)
+            })
+            .collect::<Result<Vec<_>, std::fmt::Error>>()?
+            .join(",");
+
+        if g.num_interiors() == 0 {
+            write!(f, "({})", exterior_string)
+        } else {
+            let interior_string = g
+                .interiors()
+                .map(|ring| {
+                    let s = ring
+                        .coords()
+                        .map(|c| {
+                            let mut s = String::new();
+                            coord_to_wkt(&c, &mut s)?;
+                            Ok(s)
+                        })
+                        .collect::<Result<Vec<_>, std::fmt::Error>>()?
+                        .join(",");
+                    Ok(s)
+                })
+                .collect::<Result<Vec<_>, std::fmt::Error>>()?
+                .join("),(");
+            write!(f, "({},({}))", exterior_string, interior_string)
+        }
+    } else {
+        f.write_str(" EMPTY")
+    }
+}
+
+pub fn multipoint_to_wkt<
+    T: CoordNum + WktNum + fmt::Display,
+    G: MultiPointTrait<T = T>,
+    W: Write,
+>(
+    g: &G,
+    f: &mut W,
+) -> Result<(), std::fmt::Error> {
+    let dim = g.dim();
+    // Write prefix
+    match dim {
+        geo_traits::Dimensions::Xy => f.write_str("MULTIPOINT"),
+        geo_traits::Dimensions::Xyz => f.write_str("MULTIPOINT Z"),
+        geo_traits::Dimensions::Xym => f.write_str("MULTIPOINT M"),
+        geo_traits::Dimensions::Xyzm => f.write_str("MULTIPOINT ZM"),
+        geo_traits::Dimensions::Unknown(_) => todo!(),
+    }?;
+    if g.num_points() == 0 {
+        f.write_str(" EMPTY")
+    } else {
+        let strings = g
+            .points()
+            .map(|c| {
+                let mut s = String::new();
+                // Assume no empty points within this MultiPoint
+                coord_to_wkt(&c.coord().unwrap(), &mut s)?;
+                Ok(s)
+            })
+            .collect::<Result<Vec<_>, std::fmt::Error>>()?
+            .join(",");
+        write!(f, "({})", strings)
+    }
+}
+
+pub fn multilinestring_to_wkt<
+    T: CoordNum + WktNum + fmt::Display,
+    G: MultiLineStringTrait<T = T>,
+    W: Write,
+>(
+    g: &G,
+    f: &mut W,
+) -> Result<(), std::fmt::Error> {
+    let dim = g.dim();
+    // Write prefix
+    match dim {
+        geo_traits::Dimensions::Xy => f.write_str("MULTILINESTRING"),
+        geo_traits::Dimensions::Xyz => f.write_str("MULTILINESTRING Z"),
+        geo_traits::Dimensions::Xym => f.write_str("MULTILINESTRING M"),
+        geo_traits::Dimensions::Xyzm => f.write_str("MULTILINESTRING ZM"),
+        geo_traits::Dimensions::Unknown(_) => todo!(),
+    }?;
+
+    if g.num_line_strings() == 0 {
+        f.write_str(" EMPTY")
+    } else {
+        let strings = g
+            .line_strings()
+            .map(|ring| {
+                let s = ring
+                    .coords()
+                    .map(|c| {
+                        let mut s = String::new();
+                        coord_to_wkt(&c, &mut s)?;
+                        Ok(s)
+                    })
+                    .collect::<Result<Vec<_>, std::fmt::Error>>()?
+                    .join(",");
+                Ok(s)
+            })
+            .collect::<Result<Vec<_>, std::fmt::Error>>()?
+            .join("),(");
+        write!(f, "({})", strings)
+    }
+}
+
+// pub fn multipolygon_to_wkt<
+//     T: CoordNum + WktNum + fmt::Display,
+//     G: MultiPolygonTrait<T = T>,
+//     W: Write,
+// >(
+//     g: &G,
+//     f: &mut W,
+// ) -> Result<(), std::fmt::Error> {
+//     let dim = g.dim();
+//     // Write prefix
+//     match dim {
+//         geo_traits::Dimensions::Xy => f.write_str("MULTIPOLYGON"),
+//         geo_traits::Dimensions::Xyz => f.write_str("MULTIPOLYGON Z"),
+//         geo_traits::Dimensions::Xym => f.write_str("MULTIPOLYGON M"),
+//         geo_traits::Dimensions::Xyzm => f.write_str("MULTIPOLYGON ZM"),
+//         geo_traits::Dimensions::Unknown(_) => todo!(),
+//     }?;
+
+//     if g.num_polygons() == 0 {
+//         f.write_str(" EMPTY")
+//     } else {
+//         let strings = g
+//             .polygons()
+//             .map(|polygon| {
+//                 let exterior = polygon.exterior().unwrap();
+//                 let exterior_string = exterior
+//                     .coords()
+//                     .map(|c| {
+//                         let mut s = String::new();
+//                         coord_to_wkt(&c, &mut s)?;
+//                         Ok(s)
+//                     })
+//                     .collect::<Result<Vec<_>, std::fmt::Error>>()?
+//                     .join(",");
+
+//                 if polygon.num_interiors() == 0 {
+//                     write!(f, "({})", exterior_string)
+//                 } else {
+//                     let interior_string = polygon
+//                         .interiors()
+//                         .map(|ring| {
+//                             let s = ring
+//                                 .coords()
+//                                 .map(|c| {
+//                                     let mut s = String::new();
+//                                     coord_to_wkt(&c, &mut s)?;
+//                                     Ok(s)
+//                                 })
+//                                 .collect::<Result<Vec<_>, std::fmt::Error>>()?
+//                                 .join(",");
+//                             Ok(s)
+//                         })
+//                         .collect::<Result<Vec<_>, std::fmt::Error>>()?
+//                         .join("),(");
+//                     write!(f, "({},({}))", exterior_string, interior_string)
+//                 };
+//                 Ok(s)
+//             })
+//             .collect::<Result<Vec<_>, std::fmt::Error>>()?
+//             .join("),(");
+//         write!(f, "({})", strings)
+//     }
+// }
+
+fn add_coord<T: CoordNum + WktNum + fmt::Display, G: CoordTrait<T = T>, W: Write>(
+    coord: &G,
+    f: &mut W,
+) -> Result<(), std::fmt::Error> {
+    match coord.dim().size() {
+        2 => write!(f, "{} {}", coord.x(), coord.y()),
+        3 => {
+            write!(f, "{} {} {}", coord.x(), coord.y(), coord.nth_unchecked(2))
+        }
+        4 => {
+            write!(
+                f,
+                "{} {} {} {}",
+                coord.x(),
+                coord.y(),
+                coord.nth_unchecked(2),
+                coord.nth_unchecked(3)
+            )
+        }
+        size => panic!("Unexpected dimension for coordinate: {}", size),
+    }
+}
+
+fn add_coords<T: CoordNum + WktNum + fmt::Display, W: Write, C: CoordTrait<T = T>>(
+    mut coords: impl ExactSizeIterator<Item = C>,
+    f: &mut W,
+) -> Result<(), std::fmt::Error> {
+    f.write_char('(')?;
+
+    if let Some(first_coord) = coords.next() {
+        add_coord(&first_coord, f)?;
+
+        for coord in coords {
+            f.write_char(',')?;
+            add_coord(&coord, f)?;
+        }
+    }
+
+    f.write_char(')')?;
+
+    Ok(())
+}

--- a/src/to_wkt/geo_trait_impl.rs
+++ b/src/to_wkt/geo_trait_impl.rs
@@ -6,8 +6,6 @@ use geo_traits::{
     MultiLineStringTrait, MultiPointTrait, MultiPolygonTrait, PointTrait, PolygonTrait, RectTrait,
     TriangleTrait,
 };
-#[cfg(feature = "geo-types")]
-use geo_types::CoordNum;
 
 use crate::types::{Coord, LineString, Polygon};
 use crate::WktNum;
@@ -34,7 +32,7 @@ impl From<geo_traits::Dimensions> for PhysicalCoordinateDimension {
     }
 }
 
-pub fn write_point<T: CoordNum + WktNum + fmt::Display, G: PointTrait<T = T>, W: Write>(
+pub fn write_point<T: WktNum + fmt::Display, G: PointTrait<T = T>, W: Write>(
     g: &G,
     f: &mut W,
 ) -> Result<(), std::fmt::Error> {
@@ -58,11 +56,7 @@ pub fn write_point<T: CoordNum + WktNum + fmt::Display, G: PointTrait<T = T>, W:
     }
 }
 
-pub fn write_linestring<
-    T: CoordNum + WktNum + fmt::Display,
-    G: LineStringTrait<T = T>,
-    W: Write,
->(
+pub fn write_linestring<T: WktNum + fmt::Display, G: LineStringTrait<T = T>, W: Write>(
     linestring: &G,
     f: &mut W,
 ) -> Result<(), std::fmt::Error> {
@@ -83,7 +77,7 @@ pub fn write_linestring<
     }
 }
 
-pub fn write_polygon<T: CoordNum + WktNum + fmt::Display, G: PolygonTrait<T = T>, W: Write>(
+pub fn write_polygon<T: WktNum + fmt::Display, G: PolygonTrait<T = T>, W: Write>(
     polygon: &G,
     f: &mut W,
 ) -> Result<(), std::fmt::Error> {
@@ -116,11 +110,7 @@ pub fn write_polygon<T: CoordNum + WktNum + fmt::Display, G: PolygonTrait<T = T>
     }
 }
 
-pub fn write_multi_point<
-    T: CoordNum + WktNum + fmt::Display,
-    G: MultiPointTrait<T = T>,
-    W: Write,
->(
+pub fn write_multi_point<T: WktNum + fmt::Display, G: MultiPointTrait<T = T>, W: Write>(
     multipoint: &G,
     f: &mut W,
 ) -> Result<(), std::fmt::Error> {
@@ -159,7 +149,7 @@ pub fn write_multi_point<
 }
 
 pub fn write_multi_linestring<
-    T: CoordNum + WktNum + fmt::Display,
+    T: WktNum + fmt::Display,
     G: MultiLineStringTrait<T = T>,
     W: Write,
 >(
@@ -194,11 +184,7 @@ pub fn write_multi_linestring<
     Ok(())
 }
 
-pub fn write_multi_polygon<
-    T: CoordNum + WktNum + fmt::Display,
-    G: MultiPolygonTrait<T = T>,
-    W: Write,
->(
+pub fn write_multi_polygon<T: WktNum + fmt::Display, G: MultiPolygonTrait<T = T>, W: Write>(
     multipolygon: &G,
     f: &mut W,
 ) -> Result<(), std::fmt::Error> {
@@ -244,7 +230,7 @@ pub fn write_multi_polygon<
 
 /// Create geometry to WKT representation.
 
-pub fn write_geometry<T: CoordNum + WktNum + fmt::Display, G: GeometryTrait<T = T>, W: Write>(
+pub fn write_geometry<T: WktNum + fmt::Display, G: GeometryTrait<T = T>, W: Write>(
     geometry: &G,
     f: &mut W,
 ) -> Result<(), std::fmt::Error> {
@@ -265,7 +251,7 @@ pub fn write_geometry<T: CoordNum + WktNum + fmt::Display, G: GeometryTrait<T = 
 }
 
 pub fn write_geometry_collection<
-    T: CoordNum + WktNum + fmt::Display,
+    T: WktNum + fmt::Display,
     G: GeometryCollectionTrait<T = T>,
     W: Write,
 >(
@@ -299,9 +285,7 @@ pub fn write_geometry_collection<
     Ok(())
 }
 
-fn rect_to_polygon<T: CoordNum + WktNum + fmt::Display, G: RectTrait<T = T>>(
-    rect: &G,
-) -> Polygon<T> {
+fn rect_to_polygon<T: WktNum + fmt::Display, G: RectTrait<T = T>>(rect: &G) -> Polygon<T> {
     let min_coord = rect.min();
     let max_coord = rect.max();
 
@@ -343,7 +327,7 @@ fn rect_to_polygon<T: CoordNum + WktNum + fmt::Display, G: RectTrait<T = T>>(
     Polygon(vec![ring])
 }
 
-pub fn write_rect<T: CoordNum + WktNum + fmt::Display, G: RectTrait<T = T>, W: Write>(
+pub fn write_rect<T: WktNum + fmt::Display, G: RectTrait<T = T>, W: Write>(
     rect: &G,
     f: &mut W,
 ) -> Result<(), std::fmt::Error> {
@@ -351,7 +335,7 @@ pub fn write_rect<T: CoordNum + WktNum + fmt::Display, G: RectTrait<T = T>, W: W
     write_polygon(&polygon, f)
 }
 
-pub fn write_triangle<T: CoordNum + WktNum + fmt::Display, G: TriangleTrait<T = T>, W: Write>(
+pub fn write_triangle<T: WktNum + fmt::Display, G: TriangleTrait<T = T>, W: Write>(
     triangle: &G,
     f: &mut W,
 ) -> Result<(), std::fmt::Error> {
@@ -376,7 +360,7 @@ pub fn write_triangle<T: CoordNum + WktNum + fmt::Display, G: TriangleTrait<T = 
     f.write_char(')')
 }
 
-pub fn write_line<T: CoordNum + WktNum + fmt::Display, G: LineTrait<T = T>, W: Write>(
+pub fn write_line<T: WktNum + fmt::Display, G: LineTrait<T = T>, W: Write>(
     line: &G,
     f: &mut W,
 ) -> Result<(), std::fmt::Error> {
@@ -396,7 +380,7 @@ pub fn write_line<T: CoordNum + WktNum + fmt::Display, G: LineTrait<T = T>, W: W
 /// Write a single coordinate to the writer.
 ///
 /// Will not include any start or end `()` characters.
-fn add_coord<T: CoordNum + WktNum + fmt::Display, G: CoordTrait<T = T>, W: Write>(
+fn add_coord<T: WktNum + fmt::Display, G: CoordTrait<T = T>, W: Write>(
     coord: &G,
     f: &mut W,
     size: PhysicalCoordinateDimension,
@@ -434,7 +418,7 @@ fn add_coord<T: CoordNum + WktNum + fmt::Display, G: CoordTrait<T = T>, W: Write
 /// (1 2, 3 4, 5 6)
 /// ```
 /// for a coordinate sequence with three coordinates.
-fn add_coord_sequence<T: CoordNum + WktNum + fmt::Display, W: Write, C: CoordTrait<T = T>>(
+fn add_coord_sequence<T: WktNum + fmt::Display, W: Write, C: CoordTrait<T = T>>(
     mut coords: impl Iterator<Item = C>,
     f: &mut W,
     size: PhysicalCoordinateDimension,

--- a/src/to_wkt/geo_trait_impl.rs
+++ b/src/to_wkt/geo_trait_impl.rs
@@ -16,7 +16,7 @@ use crate::WktNum;
 /// This is used so that we don't have to call `.dim()` on **every** coordinate. We infer it once
 /// from the `geo_traits::Dimensions` and then pass it to each coordinate.
 #[derive(Clone, Copy)]
-pub(crate) enum PhysicalCoordinateDimension {
+enum PhysicalCoordinateDimension {
     Two,
     Three,
     Four,
@@ -395,7 +395,7 @@ pub fn write_line<T: CoordNum + WktNum + fmt::Display, G: LineTrait<T = T>, W: W
 /// Write a single coordinate to the writer.
 ///
 /// Will not include any start or end `()` characters.
-pub(crate) fn add_coord<T: CoordNum + WktNum + fmt::Display, G: CoordTrait<T = T>, W: Write>(
+fn add_coord<T: CoordNum + WktNum + fmt::Display, G: CoordTrait<T = T>, W: Write>(
     coord: &G,
     f: &mut W,
     size: PhysicalCoordinateDimension,

--- a/src/to_wkt/geo_trait_impl.rs
+++ b/src/to_wkt/geo_trait_impl.rs
@@ -1,4 +1,4 @@
-use core::fmt;
+use std::fmt;
 use std::fmt::Write;
 
 use geo_traits::{

--- a/src/to_wkt/geo_trait_impl.rs
+++ b/src/to_wkt/geo_trait_impl.rs
@@ -33,7 +33,7 @@ impl From<geo_traits::Dimensions> for PhysicalCoordinateDimension {
     }
 }
 
-pub fn point_to_wkt<T: CoordNum + WktNum + fmt::Display, G: PointTrait<T = T>, W: Write>(
+pub fn write_point<T: CoordNum + WktNum + fmt::Display, G: PointTrait<T = T>, W: Write>(
     g: &G,
     f: &mut W,
 ) -> Result<(), std::fmt::Error> {
@@ -57,7 +57,7 @@ pub fn point_to_wkt<T: CoordNum + WktNum + fmt::Display, G: PointTrait<T = T>, W
     }
 }
 
-pub fn linestring_to_wkt<
+pub fn write_linestring<
     T: CoordNum + WktNum + fmt::Display,
     G: LineStringTrait<T = T>,
     W: Write,
@@ -82,7 +82,7 @@ pub fn linestring_to_wkt<
     }
 }
 
-pub fn polygon_to_wkt<T: CoordNum + WktNum + fmt::Display, G: PolygonTrait<T = T>, W: Write>(
+pub fn write_polygon<T: CoordNum + WktNum + fmt::Display, G: PolygonTrait<T = T>, W: Write>(
     polygon: &G,
     f: &mut W,
 ) -> Result<(), std::fmt::Error> {
@@ -115,7 +115,7 @@ pub fn polygon_to_wkt<T: CoordNum + WktNum + fmt::Display, G: PolygonTrait<T = T
     }
 }
 
-pub fn multi_point_to_wkt<
+pub fn write_multi_point<
     T: CoordNum + WktNum + fmt::Display,
     G: MultiPointTrait<T = T>,
     W: Write,
@@ -157,7 +157,7 @@ pub fn multi_point_to_wkt<
     Ok(())
 }
 
-pub fn multi_linestring_to_wkt<
+pub fn write_multi_linestring<
     T: CoordNum + WktNum + fmt::Display,
     G: MultiLineStringTrait<T = T>,
     W: Write,
@@ -193,7 +193,7 @@ pub fn multi_linestring_to_wkt<
     Ok(())
 }
 
-pub fn multi_polygon_to_wkt<
+pub fn write_multi_polygon<
     T: CoordNum + WktNum + fmt::Display,
     G: MultiPolygonTrait<T = T>,
     W: Write,
@@ -243,27 +243,27 @@ pub fn multi_polygon_to_wkt<
 
 /// Create geometry to WKT representation.
 
-pub fn geometry_to_wkt<T: CoordNum + WktNum + fmt::Display, G: GeometryTrait<T = T>, W: Write>(
+pub fn write_geometry<T: CoordNum + WktNum + fmt::Display, G: GeometryTrait<T = T>, W: Write>(
     geometry: &G,
     f: &mut W,
 ) -> Result<(), std::fmt::Error> {
     match geometry.as_type() {
-        geo_traits::GeometryType::Point(point) => point_to_wkt(point, f),
-        geo_traits::GeometryType::LineString(linestring) => linestring_to_wkt(linestring, f),
-        geo_traits::GeometryType::Polygon(polygon) => polygon_to_wkt(polygon, f),
-        geo_traits::GeometryType::MultiPoint(multi_point) => multi_point_to_wkt(multi_point, f),
-        geo_traits::GeometryType::MultiLineString(mls) => multi_linestring_to_wkt(mls, f),
+        geo_traits::GeometryType::Point(point) => write_point(point, f),
+        geo_traits::GeometryType::LineString(linestring) => write_linestring(linestring, f),
+        geo_traits::GeometryType::Polygon(polygon) => write_polygon(polygon, f),
+        geo_traits::GeometryType::MultiPoint(multi_point) => write_multi_point(multi_point, f),
+        geo_traits::GeometryType::MultiLineString(mls) => write_multi_linestring(mls, f),
         geo_traits::GeometryType::MultiPolygon(multi_polygon) => {
-            multi_polygon_to_wkt(multi_polygon, f)
+            write_multi_polygon(multi_polygon, f)
         }
-        geo_traits::GeometryType::GeometryCollection(gc) => geometry_collection_to_wkt(gc, f),
-        geo_traits::GeometryType::Rect(rect) => rect_to_wkt(rect, f),
-        geo_traits::GeometryType::Triangle(triangle) => triangle_to_wkt(triangle, f),
-        geo_traits::GeometryType::Line(line) => line_to_wkt(line, f),
+        geo_traits::GeometryType::GeometryCollection(gc) => write_geometry_collection(gc, f),
+        geo_traits::GeometryType::Rect(rect) => write_rect(rect, f),
+        geo_traits::GeometryType::Triangle(triangle) => write_triangle(triangle, f),
+        geo_traits::GeometryType::Line(line) => write_line(line, f),
     }
 }
 
-pub fn geometry_collection_to_wkt<
+pub fn write_geometry_collection<
     T: CoordNum + WktNum + fmt::Display,
     G: GeometryCollectionTrait<T = T>,
     W: Write,
@@ -285,10 +285,10 @@ pub fn geometry_collection_to_wkt<
     if let Some(first_geometry) = geometries.next() {
         f.write_str("(")?;
 
-        geometry_to_wkt(&first_geometry, f)?;
+        write_geometry(&first_geometry, f)?;
         for geom in geometries {
             f.write_char(',')?;
-            geometry_to_wkt(&geom, f)?;
+            write_geometry(&geom, f)?;
         }
 
         f.write_char(')')?;
@@ -342,15 +342,15 @@ fn rect_to_polygon<T: CoordNum + WktNum + fmt::Display, G: RectTrait<T = T>>(
     Polygon(vec![ring])
 }
 
-pub fn rect_to_wkt<T: CoordNum + WktNum + fmt::Display, G: RectTrait<T = T>, W: Write>(
+pub fn write_rect<T: CoordNum + WktNum + fmt::Display, G: RectTrait<T = T>, W: Write>(
     rect: &G,
     f: &mut W,
 ) -> Result<(), std::fmt::Error> {
     let polygon = rect_to_polygon(rect);
-    polygon_to_wkt(&polygon, f)
+    write_polygon(&polygon, f)
 }
 
-pub fn triangle_to_wkt<T: CoordNum + WktNum + fmt::Display, G: TriangleTrait<T = T>, W: Write>(
+pub fn write_triangle<T: CoordNum + WktNum + fmt::Display, G: TriangleTrait<T = T>, W: Write>(
     triangle: &G,
     f: &mut W,
 ) -> Result<(), std::fmt::Error> {
@@ -375,7 +375,7 @@ pub fn triangle_to_wkt<T: CoordNum + WktNum + fmt::Display, G: TriangleTrait<T =
     f.write_char(')')
 }
 
-pub fn line_to_wkt<T: CoordNum + WktNum + fmt::Display, G: LineTrait<T = T>, W: Write>(
+pub fn write_line<T: CoordNum + WktNum + fmt::Display, G: LineTrait<T = T>, W: Write>(
     line: &G,
     f: &mut W,
 ) -> Result<(), std::fmt::Error> {

--- a/src/to_wkt/geo_trait_impl.rs
+++ b/src/to_wkt/geo_trait_impl.rs
@@ -6,6 +6,7 @@ use geo_traits::{
     MultiLineStringTrait, MultiPointTrait, MultiPolygonTrait, PointTrait, PolygonTrait, RectTrait,
     TriangleTrait,
 };
+#[cfg(feature = "geo-types")]
 use geo_types::CoordNum;
 
 use crate::types::{Coord, LineString, Polygon};

--- a/src/to_wkt/geo_trait_impl.rs
+++ b/src/to_wkt/geo_trait_impl.rs
@@ -62,7 +62,7 @@ pub fn write_point<T: WktNum + fmt::Display, G: PointTrait<T = T>, W: Write>(
 pub fn write_linestring<T: WktNum + fmt::Display, G: LineStringTrait<T = T>, W: Write>(
     linestring: &G,
     f: &mut W,
-) -> Result<(), crate::error::Error> {
+) -> Result<(), Error> {
     let dim = linestring.dim();
     // Write prefix
     match dim {
@@ -89,7 +89,7 @@ pub fn write_linestring<T: WktNum + fmt::Display, G: LineStringTrait<T = T>, W: 
 pub fn write_polygon<T: WktNum + fmt::Display, G: PolygonTrait<T = T>, W: Write>(
     polygon: &G,
     f: &mut W,
-) -> Result<(), crate::error::Error> {
+) -> Result<(), Error> {
     let dim = polygon.dim();
     // Write prefix
     match dim {
@@ -126,7 +126,7 @@ pub fn write_polygon<T: WktNum + fmt::Display, G: PolygonTrait<T = T>, W: Write>
 pub fn write_multi_point<T: WktNum + fmt::Display, G: MultiPointTrait<T = T>, W: Write>(
     multipoint: &G,
     f: &mut W,
-) -> Result<(), crate::error::Error> {
+) -> Result<(), Error> {
     let dim = multipoint.dim();
     // Write prefix
     match dim {
@@ -174,7 +174,7 @@ pub fn write_multi_linestring<
 >(
     multilinestring: &G,
     f: &mut W,
-) -> Result<(), crate::error::Error> {
+) -> Result<(), Error> {
     let dim = multilinestring.dim();
     // Write prefix
     match dim {
@@ -212,7 +212,7 @@ pub fn write_multi_linestring<
 pub fn write_multi_polygon<T: WktNum + fmt::Display, G: MultiPolygonTrait<T = T>, W: Write>(
     multipolygon: &G,
     f: &mut W,
-) -> Result<(), crate::error::Error> {
+) -> Result<(), Error> {
     let dim = multipolygon.dim();
     // Write prefix
     match dim {
@@ -264,7 +264,7 @@ pub fn write_multi_polygon<T: WktNum + fmt::Display, G: MultiPolygonTrait<T = T>
 pub fn write_geometry<T: WktNum + fmt::Display, G: GeometryTrait<T = T>, W: Write>(
     geometry: &G,
     f: &mut W,
-) -> Result<(), crate::error::Error> {
+) -> Result<(), Error> {
     match geometry.as_type() {
         geo_traits::GeometryType::Point(point) => write_point(point, f),
         geo_traits::GeometryType::LineString(linestring) => write_linestring(linestring, f),
@@ -288,7 +288,7 @@ pub fn write_geometry_collection<
 >(
     gc: &G,
     f: &mut W,
-) -> Result<(), crate::error::Error> {
+) -> Result<(), Error> {
     let dim = gc.dim();
     // Write prefix
     match dim {
@@ -325,7 +325,7 @@ pub fn write_geometry_collection<
 pub fn write_rect<T: WktNum + fmt::Display, G: RectTrait<T = T>, W: Write>(
     rect: &G,
     f: &mut W,
-) -> Result<(), crate::error::Error> {
+) -> Result<(), Error> {
     // Write prefix and error if not 2D
     match rect.dim() {
         geo_traits::Dimensions::Xy | geo_traits::Dimensions::Unknown(2) => f.write_str("POLYGON"),
@@ -377,7 +377,7 @@ pub fn write_rect<T: WktNum + fmt::Display, G: RectTrait<T = T>, W: Write>(
 pub fn write_triangle<T: WktNum + fmt::Display, G: TriangleTrait<T = T>, W: Write>(
     triangle: &G,
     f: &mut W,
-) -> Result<(), crate::error::Error> {
+) -> Result<(), Error> {
     let dim = triangle.dim();
     // Write prefix
     match dim {
@@ -406,7 +406,7 @@ pub fn write_triangle<T: WktNum + fmt::Display, G: TriangleTrait<T = T>, W: Writ
 pub fn write_line<T: WktNum + fmt::Display, G: LineTrait<T = T>, W: Write>(
     line: &G,
     f: &mut W,
-) -> Result<(), crate::error::Error> {
+) -> Result<(), Error> {
     let dim = line.dim();
     // Write prefix
     match dim {
@@ -471,7 +471,7 @@ fn add_coord_sequence<T: WktNum + fmt::Display, W: Write, C: CoordTrait<T = T>>(
     mut coords: impl Iterator<Item = C>,
     f: &mut W,
     size: PhysicalCoordinateDimension,
-) -> Result<(), crate::error::Error> {
+) -> Result<(), Error> {
     f.write_char('(')?;
 
     if let Some(first_coord) = coords.next() {

--- a/src/to_wkt/geo_trait_impl.rs
+++ b/src/to_wkt/geo_trait_impl.rs
@@ -403,7 +403,11 @@ fn add_coord<T: CoordNum + WktNum + fmt::Display, G: CoordTrait<T = T>, W: Write
     match size {
         PhysicalCoordinateDimension::Two => write!(f, "{} {}", coord.x(), coord.y()),
         PhysicalCoordinateDimension::Three => {
-            write!(f, "{} {} {}", coord.x(), coord.y(), coord.nth_unchecked(2))
+            // Safety:
+            // We've validated that there are three dimensions
+            write!(f, "{} {} {}", coord.x(), coord.y(), unsafe {
+                coord.nth_unchecked(2)
+            })
         }
         PhysicalCoordinateDimension::Four => {
             write!(
@@ -411,8 +415,12 @@ fn add_coord<T: CoordNum + WktNum + fmt::Display, G: CoordTrait<T = T>, W: Write
                 "{} {} {} {}",
                 coord.x(),
                 coord.y(),
-                coord.nth_unchecked(2),
-                coord.nth_unchecked(3)
+                // Safety:
+                // We've validated that there are four dimensions
+                unsafe { coord.nth_unchecked(2) },
+                // Safety:
+                // We've validated that there are four dimensions
+                unsafe { coord.nth_unchecked(3) }
             )
         }
     }

--- a/src/to_wkt/mod.rs
+++ b/src/to_wkt/mod.rs
@@ -1,6 +1,12 @@
 use crate::{Wkt, WktNum};
 
-pub mod geo_trait_impl;
+mod geo_trait_impl;
+
+pub use geo_trait_impl::{
+    write_geometry, write_geometry_collection, write_line, write_linestring,
+    write_multi_linestring, write_multi_point, write_multi_polygon, write_point, write_polygon,
+    write_rect, write_triangle,
+};
 
 /// A trait for converting values to WKT
 pub trait ToWkt<T>

--- a/src/to_wkt/mod.rs
+++ b/src/to_wkt/mod.rs
@@ -1,5 +1,7 @@
 use crate::{Wkt, WktNum};
 
+pub mod geo_trait_impl;
+
 /// A trait for converting values to WKT
 pub trait ToWkt<T>
 where

--- a/src/types/coord.rs
+++ b/src/types/coord.rs
@@ -14,7 +14,7 @@
 
 use geo_traits::CoordTrait;
 
-use crate::to_wkt::geo_trait_impl::coord_to_wkt;
+use crate::to_wkt::geo_trait_impl::add_coord;
 use crate::tokenizer::{PeekableTokens, Token};
 use crate::types::Dimension;
 use crate::{FromTokens, WktNum};
@@ -37,7 +37,10 @@ where
     T: WktNum + fmt::Display,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        coord_to_wkt(self, f)
+        f.write_str("(")?;
+        add_coord(self, f, self.dim().into())?;
+        f.write_str(")")?;
+        Ok(())
     }
 }
 

--- a/src/types/coord.rs
+++ b/src/types/coord.rs
@@ -14,11 +14,9 @@
 
 use geo_traits::CoordTrait;
 
-use crate::to_wkt::geo_trait_impl::add_coord;
 use crate::tokenizer::{PeekableTokens, Token};
 use crate::types::Dimension;
 use crate::{FromTokens, WktNum};
-use std::fmt;
 use std::str::FromStr;
 
 #[derive(Clone, Debug, Default, PartialEq)]
@@ -30,18 +28,6 @@ where
     pub y: T,
     pub z: Option<T>,
     pub m: Option<T>,
-}
-
-impl<T> fmt::Display for Coord<T>
-where
-    T: WktNum + fmt::Display,
-{
-    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        f.write_str("(")?;
-        add_coord(self, f, self.dim().into())?;
-        f.write_str(")")?;
-        Ok(())
-    }
 }
 
 impl<T> FromTokens<T> for Coord<T>
@@ -186,58 +172,5 @@ impl<T: WktNum> CoordTrait for &Coord<T> {
             }
             _ => panic!("n out of range"),
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::Coord;
-
-    #[test]
-    fn write_2d_coord() {
-        let coord = Coord {
-            x: 10.1,
-            y: 20.2,
-            z: None,
-            m: None,
-        };
-
-        assert_eq!("10.1 20.2", format!("{}", coord));
-    }
-
-    #[test]
-    fn write_3d_coord() {
-        let coord = Coord {
-            x: 10.1,
-            y: 20.2,
-            z: Some(-30.3),
-            m: None,
-        };
-
-        assert_eq!("10.1 20.2 -30.3", format!("{}", coord));
-    }
-
-    #[test]
-    fn write_2d_coord_with_linear_referencing_system() {
-        let coord = Coord {
-            x: 10.1,
-            y: 20.2,
-            z: None,
-            m: Some(10.),
-        };
-
-        assert_eq!("10.1 20.2 10", format!("{}", coord));
-    }
-
-    #[test]
-    fn write_3d_coord_with_linear_referencing_system() {
-        let coord = Coord {
-            x: 10.1,
-            y: 20.2,
-            z: Some(-30.3),
-            m: Some(10.),
-        };
-
-        assert_eq!("10.1 20.2 -30.3 10", format!("{}", coord));
     }
 }

--- a/src/types/coord.rs
+++ b/src/types/coord.rs
@@ -14,6 +14,7 @@
 
 use geo_traits::CoordTrait;
 
+use crate::to_wkt::geo_trait_impl::coord_to_wkt;
 use crate::tokenizer::{PeekableTokens, Token};
 use crate::types::Dimension;
 use crate::{FromTokens, WktNum};
@@ -36,14 +37,7 @@ where
     T: WktNum + fmt::Display,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        write!(f, "{} {}", self.x, self.y)?;
-        if let Some(z) = self.z {
-            write!(f, " {}", z)?;
-        }
-        if let Some(m) = self.m {
-            write!(f, " {}", m)?;
-        }
-        Ok(())
+        coord_to_wkt(self, f)
     }
 }
 

--- a/src/types/geometrycollection.rs
+++ b/src/types/geometrycollection.rs
@@ -38,7 +38,7 @@ where
     T: WktNum + fmt::Display,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        write_geometry_collection(self, f)
+        Ok(write_geometry_collection(self, f)?)
     }
 }
 

--- a/src/types/geometrycollection.rs
+++ b/src/types/geometrycollection.rs
@@ -38,7 +38,7 @@ where
     T: WktNum + fmt::Display,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        Ok(write_geometry_collection(self, f)?)
+        Ok(write_geometry_collection(f, self)?)
     }
 }
 

--- a/src/types/geometrycollection.rs
+++ b/src/types/geometrycollection.rs
@@ -14,7 +14,7 @@
 
 use geo_traits::{GeometryCollectionTrait, GeometryTrait};
 
-use crate::to_wkt::geo_trait_impl::geometry_collection_to_wkt;
+use crate::to_wkt::geo_trait_impl::write_geometry_collection;
 use crate::tokenizer::{PeekableTokens, Token};
 use crate::types::Dimension;
 use crate::{FromTokens, Wkt, WktNum};
@@ -38,7 +38,7 @@ where
     T: WktNum + fmt::Display,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        geometry_collection_to_wkt(self, f)
+        write_geometry_collection(self, f)
     }
 }
 

--- a/src/types/geometrycollection.rs
+++ b/src/types/geometrycollection.rs
@@ -14,7 +14,7 @@
 
 use geo_traits::{GeometryCollectionTrait, GeometryTrait};
 
-use crate::to_wkt::geo_trait_impl::write_geometry_collection;
+use crate::to_wkt::write_geometry_collection;
 use crate::tokenizer::{PeekableTokens, Token};
 use crate::types::Dimension;
 use crate::{FromTokens, Wkt, WktNum};

--- a/src/types/geometrycollection.rs
+++ b/src/types/geometrycollection.rs
@@ -14,6 +14,7 @@
 
 use geo_traits::{GeometryCollectionTrait, GeometryTrait};
 
+use crate::to_wkt::geo_trait_impl::geometry_collection_to_wkt;
 use crate::tokenizer::{PeekableTokens, Token};
 use crate::types::Dimension;
 use crate::{FromTokens, Wkt, WktNum};
@@ -37,18 +38,7 @@ where
     T: WktNum + fmt::Display,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        if self.0.is_empty() {
-            f.write_str("GEOMETRYCOLLECTION EMPTY")
-        } else {
-            let strings = self
-                .0
-                .iter()
-                .map(|geometry| format!("{}", geometry))
-                .collect::<Vec<_>>()
-                .join(",");
-
-            write!(f, "GEOMETRYCOLLECTION({})", strings)
-        }
+        geometry_collection_to_wkt(self, f)
     }
 }
 

--- a/src/types/linestring.rs
+++ b/src/types/linestring.rs
@@ -14,7 +14,7 @@
 
 use geo_traits::{CoordTrait, LineStringTrait};
 
-use crate::to_wkt::geo_trait_impl::linestring_to_wkt;
+use crate::to_wkt::geo_trait_impl::write_linestring;
 use crate::tokenizer::PeekableTokens;
 use crate::types::coord::Coord;
 use crate::types::Dimension;
@@ -49,7 +49,7 @@ where
     T: WktNum + fmt::Display,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        linestring_to_wkt(self, f)
+        write_linestring(self, f)
     }
 }
 

--- a/src/types/linestring.rs
+++ b/src/types/linestring.rs
@@ -14,6 +14,7 @@
 
 use geo_traits::{CoordTrait, LineStringTrait};
 
+use crate::to_wkt::geo_trait_impl::linestring_to_wkt;
 use crate::tokenizer::PeekableTokens;
 use crate::types::coord::Coord;
 use crate::types::Dimension;
@@ -48,18 +49,7 @@ where
     T: WktNum + fmt::Display,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        if self.0.is_empty() {
-            f.write_str("LINESTRING EMPTY")
-        } else {
-            let strings = self
-                .0
-                .iter()
-                .map(|c| format!("{}", c))
-                .collect::<Vec<_>>()
-                .join(",");
-
-            write!(f, "LINESTRING({})", strings)
-        }
+        linestring_to_wkt(self, f)
     }
 }
 

--- a/src/types/linestring.rs
+++ b/src/types/linestring.rs
@@ -14,7 +14,7 @@
 
 use geo_traits::{CoordTrait, LineStringTrait};
 
-use crate::to_wkt::geo_trait_impl::write_linestring;
+use crate::to_wkt::write_linestring;
 use crate::tokenizer::PeekableTokens;
 use crate::types::coord::Coord;
 use crate::types::Dimension;

--- a/src/types/linestring.rs
+++ b/src/types/linestring.rs
@@ -49,7 +49,7 @@ where
     T: WktNum + fmt::Display,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        write_linestring(self, f)
+        Ok(write_linestring(self, f)?)
     }
 }
 

--- a/src/types/linestring.rs
+++ b/src/types/linestring.rs
@@ -49,7 +49,7 @@ where
     T: WktNum + fmt::Display,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        Ok(write_linestring(self, f)?)
+        Ok(write_linestring(f, self)?)
     }
 }
 

--- a/src/types/multilinestring.rs
+++ b/src/types/multilinestring.rs
@@ -14,7 +14,7 @@
 
 use geo_traits::{LineStringTrait, MultiLineStringTrait};
 
-use crate::to_wkt::geo_trait_impl::write_multi_linestring;
+use crate::to_wkt::write_multi_linestring;
 use crate::tokenizer::PeekableTokens;
 use crate::types::linestring::LineString;
 use crate::types::Dimension;

--- a/src/types/multilinestring.rs
+++ b/src/types/multilinestring.rs
@@ -14,6 +14,7 @@
 
 use geo_traits::{LineStringTrait, MultiLineStringTrait};
 
+use crate::to_wkt::geo_trait_impl::multilinestring_to_wkt;
 use crate::tokenizer::PeekableTokens;
 use crate::types::linestring::LineString;
 use crate::types::Dimension;
@@ -38,23 +39,7 @@ where
     T: WktNum + fmt::Display,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        if self.0.is_empty() {
-            f.write_str("MULTILINESTRING EMPTY")
-        } else {
-            let strings = self
-                .0
-                .iter()
-                .map(|l| {
-                    l.0.iter()
-                        .map(|c| format!("{} {}", c.x, c.y))
-                        .collect::<Vec<_>>()
-                        .join(",")
-                })
-                .collect::<Vec<_>>()
-                .join("),(");
-
-            write!(f, "MULTILINESTRING(({}))", strings)
-        }
+        multilinestring_to_wkt(self, f)
     }
 }
 

--- a/src/types/multilinestring.rs
+++ b/src/types/multilinestring.rs
@@ -14,7 +14,7 @@
 
 use geo_traits::{LineStringTrait, MultiLineStringTrait};
 
-use crate::to_wkt::geo_trait_impl::multi_linestring_to_wkt;
+use crate::to_wkt::geo_trait_impl::write_multi_linestring;
 use crate::tokenizer::PeekableTokens;
 use crate::types::linestring::LineString;
 use crate::types::Dimension;
@@ -39,7 +39,7 @@ where
     T: WktNum + fmt::Display,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        multi_linestring_to_wkt(self, f)
+        write_multi_linestring(self, f)
     }
 }
 

--- a/src/types/multilinestring.rs
+++ b/src/types/multilinestring.rs
@@ -39,7 +39,7 @@ where
     T: WktNum + fmt::Display,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        Ok(write_multi_linestring(self, f)?)
+        Ok(write_multi_linestring(f, self)?)
     }
 }
 

--- a/src/types/multilinestring.rs
+++ b/src/types/multilinestring.rs
@@ -39,7 +39,7 @@ where
     T: WktNum + fmt::Display,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        write_multi_linestring(self, f)
+        Ok(write_multi_linestring(self, f)?)
     }
 }
 

--- a/src/types/multilinestring.rs
+++ b/src/types/multilinestring.rs
@@ -14,7 +14,7 @@
 
 use geo_traits::{LineStringTrait, MultiLineStringTrait};
 
-use crate::to_wkt::geo_trait_impl::multilinestring_to_wkt;
+use crate::to_wkt::geo_trait_impl::multi_linestring_to_wkt;
 use crate::tokenizer::PeekableTokens;
 use crate::types::linestring::LineString;
 use crate::types::Dimension;
@@ -39,7 +39,7 @@ where
     T: WktNum + fmt::Display,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        multilinestring_to_wkt(self, f)
+        multi_linestring_to_wkt(self, f)
     }
 }
 

--- a/src/types/multipoint.rs
+++ b/src/types/multipoint.rs
@@ -14,7 +14,7 @@
 
 use geo_traits::{MultiPointTrait, PointTrait};
 
-use crate::to_wkt::geo_trait_impl::write_multi_point;
+use crate::to_wkt::write_multi_point;
 use crate::tokenizer::PeekableTokens;
 use crate::types::point::Point;
 use crate::types::Dimension;

--- a/src/types/multipoint.rs
+++ b/src/types/multipoint.rs
@@ -14,6 +14,7 @@
 
 use geo_traits::{MultiPointTrait, PointTrait};
 
+use crate::to_wkt::geo_trait_impl::multipoint_to_wkt;
 use crate::tokenizer::PeekableTokens;
 use crate::types::point::Point;
 use crate::types::Dimension;
@@ -38,19 +39,7 @@ where
     T: WktNum + fmt::Display,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        if self.0.is_empty() {
-            f.write_str("MULTIPOINT EMPTY")
-        } else {
-            let strings = self
-                .0
-                .iter()
-                .filter_map(|p| p.0.as_ref())
-                .map(|c| format!("({} {})", c.x, c.y))
-                .collect::<Vec<_>>()
-                .join(",");
-
-            write!(f, "MULTIPOINT({})", strings)
-        }
+        multipoint_to_wkt(self, f)
     }
 }
 

--- a/src/types/multipoint.rs
+++ b/src/types/multipoint.rs
@@ -14,7 +14,7 @@
 
 use geo_traits::{MultiPointTrait, PointTrait};
 
-use crate::to_wkt::geo_trait_impl::multi_point_to_wkt;
+use crate::to_wkt::geo_trait_impl::write_multi_point;
 use crate::tokenizer::PeekableTokens;
 use crate::types::point::Point;
 use crate::types::Dimension;
@@ -39,7 +39,7 @@ where
     T: WktNum + fmt::Display,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        multi_point_to_wkt(self, f)
+        write_multi_point(self, f)
     }
 }
 

--- a/src/types/multipoint.rs
+++ b/src/types/multipoint.rs
@@ -14,7 +14,7 @@
 
 use geo_traits::{MultiPointTrait, PointTrait};
 
-use crate::to_wkt::geo_trait_impl::multipoint_to_wkt;
+use crate::to_wkt::geo_trait_impl::multi_point_to_wkt;
 use crate::tokenizer::PeekableTokens;
 use crate::types::point::Point;
 use crate::types::Dimension;
@@ -39,7 +39,7 @@ where
     T: WktNum + fmt::Display,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        multipoint_to_wkt(self, f)
+        multi_point_to_wkt(self, f)
     }
 }
 

--- a/src/types/multipoint.rs
+++ b/src/types/multipoint.rs
@@ -39,7 +39,7 @@ where
     T: WktNum + fmt::Display,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        Ok(write_multi_point(self, f)?)
+        Ok(write_multi_point(f, self)?)
     }
 }
 

--- a/src/types/multipoint.rs
+++ b/src/types/multipoint.rs
@@ -39,7 +39,7 @@ where
     T: WktNum + fmt::Display,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        write_multi_point(self, f)
+        Ok(write_multi_point(self, f)?)
     }
 }
 

--- a/src/types/multipolygon.rs
+++ b/src/types/multipolygon.rs
@@ -39,7 +39,7 @@ where
     T: WktNum + fmt::Display,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        write_multi_polygon(self, f)
+        Ok(write_multi_polygon(self, f)?)
     }
 }
 

--- a/src/types/multipolygon.rs
+++ b/src/types/multipolygon.rs
@@ -14,7 +14,7 @@
 
 use geo_traits::{MultiPolygonTrait, PolygonTrait};
 
-use crate::to_wkt::geo_trait_impl::write_multi_polygon;
+use crate::to_wkt::write_multi_polygon;
 use crate::tokenizer::PeekableTokens;
 use crate::types::polygon::Polygon;
 use crate::types::Dimension;

--- a/src/types/multipolygon.rs
+++ b/src/types/multipolygon.rs
@@ -14,7 +14,7 @@
 
 use geo_traits::{MultiPolygonTrait, PolygonTrait};
 
-use crate::to_wkt::geo_trait_impl::multi_polygon_to_wkt;
+use crate::to_wkt::geo_trait_impl::write_multi_polygon;
 use crate::tokenizer::PeekableTokens;
 use crate::types::polygon::Polygon;
 use crate::types::Dimension;
@@ -39,7 +39,7 @@ where
     T: WktNum + fmt::Display,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        multi_polygon_to_wkt(self, f)
+        write_multi_polygon(self, f)
     }
 }
 

--- a/src/types/multipolygon.rs
+++ b/src/types/multipolygon.rs
@@ -39,7 +39,7 @@ where
     T: WktNum + fmt::Display,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        Ok(write_multi_polygon(self, f)?)
+        Ok(write_multi_polygon(f, self)?)
     }
 }
 

--- a/src/types/multipolygon.rs
+++ b/src/types/multipolygon.rs
@@ -14,6 +14,7 @@
 
 use geo_traits::{MultiPolygonTrait, PolygonTrait};
 
+use crate::to_wkt::geo_trait_impl::multi_polygon_to_wkt;
 use crate::tokenizer::PeekableTokens;
 use crate::types::polygon::Polygon;
 use crate::types::Dimension;
@@ -38,28 +39,7 @@ where
     T: WktNum + fmt::Display,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        if self.0.is_empty() {
-            f.write_str("MULTIPOLYGON EMPTY")
-        } else {
-            let strings = self
-                .0
-                .iter()
-                .map(|p| {
-                    p.0.iter()
-                        .map(|l| {
-                            l.0.iter()
-                                .map(|c| format!("{} {}", c.x, c.y))
-                                .collect::<Vec<String>>()
-                                .join(",")
-                        })
-                        .collect::<Vec<String>>()
-                        .join("),(")
-                })
-                .collect::<Vec<String>>()
-                .join(")),((");
-
-            write!(f, "MULTIPOLYGON((({})))", strings)
-        }
+        multi_polygon_to_wkt(self, f)
     }
 }
 

--- a/src/types/point.rs
+++ b/src/types/point.rs
@@ -39,7 +39,7 @@ where
     T: WktNum + fmt::Display,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        write_point(self, f)
+        Ok(write_point(self, f)?)
     }
 }
 

--- a/src/types/point.rs
+++ b/src/types/point.rs
@@ -14,7 +14,7 @@
 
 use geo_traits::{CoordTrait, PointTrait};
 
-use crate::to_wkt::geo_trait_impl::write_point;
+use crate::to_wkt::write_point;
 use crate::tokenizer::PeekableTokens;
 use crate::types::coord::Coord;
 use crate::types::Dimension;

--- a/src/types/point.rs
+++ b/src/types/point.rs
@@ -14,6 +14,7 @@
 
 use geo_traits::{CoordTrait, PointTrait};
 
+use crate::to_wkt::geo_trait_impl::point_to_wkt;
 use crate::tokenizer::PeekableTokens;
 use crate::types::coord::Coord;
 use crate::types::Dimension;
@@ -38,23 +39,7 @@ where
     T: WktNum + fmt::Display,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        match self.0 {
-            Some(ref coord) => {
-                let mut lrs = String::new();
-                if coord.z.is_some() {
-                    lrs += "Z";
-                }
-                if coord.m.is_some() {
-                    lrs += "M";
-                }
-                if !lrs.is_empty() {
-                    lrs = " ".to_string() + &lrs;
-                }
-
-                write!(f, "POINT{}({})", lrs, coord)
-            }
-            None => f.write_str("POINT EMPTY"),
-        }
+        point_to_wkt(self, f)
     }
 }
 

--- a/src/types/point.rs
+++ b/src/types/point.rs
@@ -39,7 +39,7 @@ where
     T: WktNum + fmt::Display,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        Ok(write_point(self, f)?)
+        Ok(write_point(f, self)?)
     }
 }
 

--- a/src/types/point.rs
+++ b/src/types/point.rs
@@ -14,7 +14,7 @@
 
 use geo_traits::{CoordTrait, PointTrait};
 
-use crate::to_wkt::geo_trait_impl::point_to_wkt;
+use crate::to_wkt::geo_trait_impl::write_point;
 use crate::tokenizer::PeekableTokens;
 use crate::types::coord::Coord;
 use crate::types::Dimension;
@@ -39,7 +39,7 @@ where
     T: WktNum + fmt::Display,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        point_to_wkt(self, f)
+        write_point(self, f)
     }
 }
 

--- a/src/types/polygon.rs
+++ b/src/types/polygon.rs
@@ -39,7 +39,7 @@ where
     T: WktNum + fmt::Display,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        Ok(write_polygon(self, f)?)
+        Ok(write_polygon(f, self)?)
     }
 }
 

--- a/src/types/polygon.rs
+++ b/src/types/polygon.rs
@@ -14,7 +14,7 @@
 
 use geo_traits::{LineStringTrait, PolygonTrait};
 
-use crate::to_wkt::geo_trait_impl::write_polygon;
+use crate::to_wkt::write_polygon;
 use crate::tokenizer::PeekableTokens;
 use crate::types::linestring::LineString;
 use crate::types::Dimension;

--- a/src/types/polygon.rs
+++ b/src/types/polygon.rs
@@ -14,6 +14,7 @@
 
 use geo_traits::{LineStringTrait, PolygonTrait};
 
+use crate::to_wkt::geo_trait_impl::polygon_to_wkt;
 use crate::tokenizer::PeekableTokens;
 use crate::types::linestring::LineString;
 use crate::types::Dimension;
@@ -38,23 +39,7 @@ where
     T: WktNum + fmt::Display,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        if self.0.is_empty() {
-            f.write_str("POLYGON EMPTY")
-        } else {
-            let strings = self
-                .0
-                .iter()
-                .map(|l| {
-                    l.0.iter()
-                        .map(|c| format!("{} {}", c.x, c.y))
-                        .collect::<Vec<_>>()
-                        .join(",")
-                })
-                .collect::<Vec<_>>()
-                .join("),(");
-
-            write!(f, "POLYGON(({}))", strings)
-        }
+        polygon_to_wkt(self, f)
     }
 }
 

--- a/src/types/polygon.rs
+++ b/src/types/polygon.rs
@@ -39,7 +39,7 @@ where
     T: WktNum + fmt::Display,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        write_polygon(self, f)
+        Ok(write_polygon(self, f)?)
     }
 }
 

--- a/src/types/polygon.rs
+++ b/src/types/polygon.rs
@@ -14,7 +14,7 @@
 
 use geo_traits::{LineStringTrait, PolygonTrait};
 
-use crate::to_wkt::geo_trait_impl::polygon_to_wkt;
+use crate::to_wkt::geo_trait_impl::write_polygon;
 use crate::tokenizer::PeekableTokens;
 use crate::types::linestring::LineString;
 use crate::types::Dimension;
@@ -39,7 +39,7 @@ where
     T: WktNum + fmt::Display,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        polygon_to_wkt(self, f)
+        write_polygon(self, f)
     }
 }
 


### PR DESCRIPTION
- [ ] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [ ] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
- [x] I ran cargo fmt
---

### Changes:

This slightly changes the implementation for writing to WKT, partially based on @b4l's PR here https://github.com/geoarrow/geoarrow-rs/pull/788.

While porting the code to use traits, I realized that there was an _awful lot_ of string concatenation being performed. So for example, when writing a Polygon to WKT, **every single coordinate** would be allocated to a separate string, and then the coords of each **ring** would be concatenated and then **all rings** would be concatenated.

https://github.com/georust/wkt/blob/e1d838de2218f410422da28a23c26a7f6329505d/src/types/polygon.rs#L42-L52

This instead writes coordinates _directly_ to the output writer. So perhaps the performance differences in the discussion here https://github.com/georust/wkt/issues/118 were not primarily due to `ryu`.

This PR also implements writing for geo-traits objects, and delegates the `std::fmt::Display` implementation to the underlying geo-traits impl.

Benchmark against `main`:

```
> cargo bench --bench write
Gnuplot not found, using plotters backend
to_string small wkt     time:   [719.98 ns 723.19 ns 726.51 ns]
                        change: [-33.175% -32.566% -32.039%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 17 outliers among 100 measurements (17.00%)
  5 (5.00%) low severe
  3 (3.00%) low mild
  2 (2.00%) high mild
  7 (7.00%) high severe

to_string big wkt       time:   [2.3337 ms 2.3425 ms 2.3524 ms]
                        change: [-44.006% -43.647% -43.297%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  3 (3.00%) high mild
  2 (2.00%) high severe

geo: serialize small wkt string
                        time:   [818.73 ns 826.57 ns 836.32 ns]
                        change: [-44.024% -37.443% -31.192%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  7 (7.00%) high mild
  2 (2.00%) high severe

geo: serialize big wkt string
                        time:   [2.4689 ms 2.5142 ms 2.5899 ms]
                        change: [-45.157% -42.370% -39.852%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  1 (1.00%) high mild
  4 (4.00%) high severe

geo: write small wkt    time:   [815.24 ns 821.34 ns 831.63 ns]
                        change: [-30.751% -28.806% -27.455%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  3 (3.00%) high mild
  1 (1.00%) high severe

geo: write big wkt      time:   [2.4814 ms 2.4877 ms 2.4941 ms]
                        change: [-49.589% -45.273% -42.171%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 23 outliers among 100 measurements (23.00%)
  14 (14.00%) low severe
  4 (4.00%) low mild
  2 (2.00%) high mild
  3 (3.00%) high severe
```

I also added another bench for writing the `geo::Geometry` object _directly_ instead of first converting it to a `wkt::Wkt`. It's not 100% apples to oranges because I can't use `std::io::sink()` for a `std::fmt::Write` trait input. But it's still faster 🤷‍♂️ 

```
geo: write small wkt    time:   [809.53 ns 812.46 ns 815.71 ns]
                        change: [-1.9040% -1.1064% -0.5136%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 12 outliers among 100 measurements (12.00%)
  1 (1.00%) low severe
  4 (4.00%) low mild
  5 (5.00%) high mild
  2 (2.00%) high severe

geo: write big wkt      time:   [2.5784 ms 2.6684 ms 2.8063 ms]
                        change: [+3.6982% +7.2652% +13.562%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 14 outliers among 100 measurements (14.00%)
  3 (3.00%) high mild
  11 (11.00%) high severe

geo: write small wkt using trait
                        time:   [689.63 ns 692.96 ns 696.94 ns]
Found 8 outliers among 100 measurements (8.00%)
  3 (3.00%) high mild
  5 (5.00%) high severe

geo: write big wkt using trait
                        time:   [2.3611 ms 2.3872 ms 2.4283 ms]
Found 7 outliers among 100 measurements (7.00%)
  1 (1.00%) high mild
  6 (6.00%) high severe
```