### PR TITLE
Update `ToWkt::write_wkt` to not buffer string

### DIFF
--- a/src/geo_types_to_wkt.rs
+++ b/src/geo_types_to_wkt.rs
@@ -1,6 +1,5 @@
 use geo_types::CoordNum;
 
-use crate::to_wkt::{write_multi_polygon, write_point};
 use crate::types::{
     Coord, GeometryCollection, LineString, MultiLineString, MultiPoint, MultiPolygon, Point,
     Polygon,
@@ -36,17 +35,6 @@ where
     }
 }
 
-/// A wrapper around something that implements std::io::Write to be used with our writer traits,
-/// which require std::fmt::Write
-struct WriterWrapper<W: std::io::Write>(W);
-
-impl<W: std::io::Write> std::fmt::Write for WriterWrapper<W> {
-    fn write_str(&mut self, s: &str) -> std::fmt::Result {
-        self.0.write(s.as_bytes()).map_err(|_| std::fmt::Error)?;
-        Ok(())
-    }
-}
-
 /// # Examples
 /// ```
 /// use geo_types::{point, Point};
@@ -62,17 +50,6 @@ where
 {
     fn to_wkt(&self) -> Wkt<T> {
         Wkt::Point(g_point_to_w_point(self))
-    }
-
-    fn wkt_string(&self) -> String {
-        let mut s = String::new();
-        write_point(&mut s, self).unwrap();
-        s
-    }
-
-    fn write_wkt(&self, writer: impl std::io::Write) -> std::io::Result<()> {
-        write_point(&mut WriterWrapper(writer), self).unwrap();
-        Ok(())
     }
 }
 
@@ -187,17 +164,6 @@ where
 {
     fn to_wkt(&self) -> Wkt<T> {
         g_mpolygon_to_w_mpolygon(self).into()
-    }
-
-    fn wkt_string(&self) -> String {
-        let mut s = String::new();
-        write_multi_polygon(&mut s, self).unwrap();
-        s
-    }
-
-    fn write_wkt(&self, writer: impl std::io::Write) -> std::io::Result<()> {
-        write_multi_polygon(&mut WriterWrapper(writer), self).unwrap();
-        Ok(())
     }
 }
 

--- a/src/geo_types_to_wkt.rs
+++ b/src/geo_types_to_wkt.rs
@@ -1,6 +1,6 @@
 use geo_types::CoordNum;
 
-use crate::to_wkt::write_point;
+use crate::to_wkt::{write_multi_polygon, write_point};
 use crate::types::{
     Coord, GeometryCollection, LineString, MultiLineString, MultiPoint, MultiPolygon, Point,
     Polygon,
@@ -187,6 +187,17 @@ where
 {
     fn to_wkt(&self) -> Wkt<T> {
         g_mpolygon_to_w_mpolygon(self).into()
+    }
+
+    fn wkt_string(&self) -> String {
+        let mut s = String::new();
+        write_multi_polygon(&mut s, self).unwrap();
+        s
+    }
+
+    fn write_wkt(&self, writer: impl std::io::Write) -> std::io::Result<()> {
+        write_multi_polygon(&mut WriterWrapper(writer), self).unwrap();
+        Ok(())
     }
 }
 

--- a/src/geo_types_to_wkt.rs
+++ b/src/geo_types_to_wkt.rs
@@ -1,5 +1,6 @@
 use geo_types::CoordNum;
 
+use crate::to_wkt::write_point;
 use crate::types::{
     Coord, GeometryCollection, LineString, MultiLineString, MultiPoint, MultiPolygon, Point,
     Polygon,
@@ -35,6 +36,17 @@ where
     }
 }
 
+/// A wrapper around something that implements std::io::Write to be used with our writer traits,
+/// which require std::fmt::Write
+struct WriterWrapper<W: std::io::Write>(W);
+
+impl<W: std::io::Write> std::fmt::Write for WriterWrapper<W> {
+    fn write_str(&mut self, s: &str) -> std::fmt::Result {
+        self.0.write(s.as_bytes()).map_err(|_| std::fmt::Error)?;
+        Ok(())
+    }
+}
+
 /// # Examples
 /// ```
 /// use geo_types::{point, Point};
@@ -50,6 +62,17 @@ where
 {
     fn to_wkt(&self) -> Wkt<T> {
         Wkt::Point(g_point_to_w_point(self))
+    }
+
+    fn wkt_string(&self) -> String {
+        let mut s = String::new();
+        write_point(&mut s, self).unwrap();
+        s
+    }
+
+    fn write_wkt(&self, writer: impl std::io::Write) -> std::io::Result<()> {
+        write_point(&mut WriterWrapper(writer), self).unwrap();
+        Ok(())
     }
 }
 

--- a/src/to_wkt/mod.rs
+++ b/src/to_wkt/mod.rs
@@ -61,10 +61,6 @@ where
     ///
     /// assert_eq!(wkt_string, "POINT(1.2 3.4)");
     /// ```
-    ///
-    /// ## Panics
-    ///
-    /// - If
     fn write_wkt(&self, writer: impl std::io::Write) -> std::io::Result<()> {
         write_geometry(&mut WriterWrapper(writer), &self.to_wkt())
             .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err.to_string()))


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [ ] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
- [x] I ran cargo fmt
---

This avoids buffering when writing WKT to `std::io::Write`. It's considerably faster:

```
geo: write small wkt    time:   [570.44 ns 573.74 ns 578.31 ns]
                        change: [-30.487% -29.975% -29.481%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  1 (1.00%) high mild
  8 (8.00%) high severe

geo: write big wkt      time:   [2.0220 ms 2.0300 ms 2.0405 ms]
                        change: [-19.849% -19.214% -18.603%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  1 (1.00%) high mild
  4 (4.00%) high severe
```
