### PR TITLE
geo-types-0.7.16 has new winding order for Rect

### DIFF
--- a/src/geo_types_to_wkt.rs
+++ b/src/geo_types_to_wkt.rs
@@ -194,7 +194,7 @@ where
 ///
 /// let rect: Rect<f64> = Rect::new(coord!(x: 4., y: 4.), coord!(x: 8., y: 8.));
 ///
-/// assert_eq!(rect.wkt_string(), "POLYGON((4 4,4 8,8 8,8 4,4 4))");
+/// assert_eq!(rect.wkt_string(), "POLYGON((8 4,8 8,4 8,4 4,8 4))");
 /// ```
 impl<T> ToWkt<T> for geo_types::Rect<T>
 where


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
- [x] I ran cargo fmt
---

