### PR TITLE
Store dimension in wkt types

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,10 @@
 
 ## 0.13.0 - unreleased
 
+* BREAKING: Store dimension in wkt types (#135)
+  * This removes the publicly-accessible tuple member for each struct in `wkt::types`. Use public constructors to construct new objects and new public accessors to access internal data.
+  * WKT dimension is now always correctly inferred from the WKT string, even for empty geometries.
+  * `infer_type` now never returns `None`.
 * Remove allocation to `Wkt` when writing geo-types via `write_wkt` (#140)
 * Default to using `f64` for `WktNum` in WKT types
 * Add `Copy` impl to `Coord`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,6 @@ serde_json = "1.0"
 
 [features]
 default = ["geo-types"]
-geo-types = ["dep:geo-types", "geo-traits/geo-types"]
 
 [[bench]]
 name = "parse"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ serde_json = "1.0"
 
 [features]
 default = ["geo-types"]
+geo-types = ["dep:geo-types", "geo-traits/geo-types"]
 
 [[bench]]
 name = "parse"

--- a/src/deserialize/mod.rs
+++ b/src/deserialize/mod.rs
@@ -196,12 +196,15 @@ mod tests {
                 .unwrap();
             assert!(matches!(
                 wkt,
-                Wkt::Point(Point(Some(Coord {
-                    x: _, // floating-point types cannot be used in patterns
-                    y: _, // floating-point types cannot be used in patterns
-                    z: None,
-                    m: None,
-                })))
+                Wkt::Point(Point {
+                    coord: Some(Coord {
+                        x: _, // floating-point types cannot be used in patterns
+                        y: _, // floating-point types cannot be used in patterns
+                        z: None,
+                        m: None,
+                    }),
+                    dim: _dim,
+                })
             ));
         }
 
@@ -227,12 +230,15 @@ mod tests {
                 .unwrap();
             assert!(matches!(
                 geometry,
-                Wkt::Point(Point(Some(Coord {
-                    x: _, // floating-point types cannot be used in patterns
-                    y: _, // floating-point types cannot be used in patterns
-                    z: None,
-                    m: None,
-                })))
+                Wkt::Point(Point {
+                    coord: Some(Coord {
+                        x: _, // floating-point types cannot be used in patterns
+                        y: _, // floating-point types cannot be used in patterns
+                        z: None,
+                        m: None,
+                    }),
+                    dim: _dim,
+                })
             ));
         }
 

--- a/src/geo_types_from_wkt.rs
+++ b/src/geo_types_from_wkt.rs
@@ -90,8 +90,11 @@ impl<T: CoordNum> TryFrom<Wkt<T>> for geo_types::GeometryCollection<T> {
     fn try_from(wkt: Wkt<T>) -> Result<Self, Self::Error> {
         match wkt {
             Wkt::GeometryCollection(collection) => {
-                let geometries: Result<Vec<geo_types::Geometry<T>>, _> =
-                    collection.0.into_iter().map(TryFrom::try_from).collect();
+                let geometries: Result<Vec<geo_types::Geometry<T>>, _> = collection
+                    .geoms
+                    .into_iter()
+                    .map(TryFrom::try_from)
+                    .collect();
                 Ok(geo_types::GeometryCollection(geometries?))
             }
             // geo_types doesn't implement `Geometry::try_from(geom_collec)` yet
@@ -143,7 +146,7 @@ where
 
     /// Fallibly convert from a WKT `POINT` to a [`geo_types::Point`]
     fn try_from(point: Point<T>) -> Result<Self, Self::Error> {
-        match point.0 {
+        match point.coord {
             Some(coord) => Ok(Self::new(coord.x, coord.y)),
             None => Err(Error::PointConversionError),
         }
@@ -174,7 +177,7 @@ where
     /// Convert from a WKT `LINESTRING` to a [`geo_types::LineString`]
     fn from(line_string: LineString<T>) -> Self {
         let coords = line_string
-            .0
+            .coords
             .into_iter()
             .map(geo_types::Coord::from)
             .collect();
@@ -199,7 +202,7 @@ where
     /// Convert from a WKT `MULTILINESTRING` to a [`geo_types::MultiLineString`]
     fn from(multi_line_string: MultiLineString<T>) -> geo_types::MultiLineString<T> {
         let geo_line_strings: Vec<geo_types::LineString<T>> = multi_line_string
-            .0
+            .line_strings
             .into_iter()
             .map(geo_types::LineString::from)
             .collect();
@@ -223,7 +226,7 @@ where
 {
     /// Convert from a WKT `POLYGON` to a [`geo_types::Polygon`]
     fn from(polygon: Polygon<T>) -> Self {
-        let mut iter = polygon.0.into_iter().map(geo_types::LineString::from);
+        let mut iter = polygon.rings.into_iter().map(geo_types::LineString::from);
         match iter.next() {
             Some(interior) => geo_types::Polygon::new(interior, iter.collect()),
             None => geo_types::Polygon::new(geo_types::LineString(vec![]), vec![]),
@@ -250,7 +253,7 @@ where
     /// Fallibly convert from a WKT `MULTIPOINT` to a [`geo_types::MultiPoint`]
     fn try_from(multi_point: MultiPoint<T>) -> Result<Self, Self::Error> {
         let points: Vec<geo_types::Point<T>> = multi_point
-            .0
+            .points
             .into_iter()
             .map(geo_types::Point::try_from)
             .collect::<Result<Vec<_>, _>>()?;
@@ -275,7 +278,7 @@ where
     /// Convert from a WKT `MULTIPOLYGON` to a [`geo_types::MultiPolygon`]
     fn from(multi_polygon: MultiPolygon<T>) -> Self {
         let geo_polygons: Vec<geo_types::Polygon<T>> = multi_polygon
-            .0
+            .polygons
             .into_iter()
             .map(geo_types::Polygon::from)
             .collect();
@@ -304,7 +307,7 @@ where
 
     fn try_from(geometry_collection: GeometryCollection<T>) -> Result<Self, Self::Error> {
         let geo_geometries = geometry_collection
-            .0
+            .geoms
             .into_iter()
             .map(Wkt::try_into)
             .collect::<Result<_, _>>()?;
@@ -323,7 +326,7 @@ where
         Ok(match geometry {
             Wkt::Point(g) => {
                 // Special case as `geo::Point` can't be empty
-                if g.0.is_some() {
+                if g.coord.is_some() {
                     geo_types::Point::try_from(g)?.into()
                 } else {
                     geo_types::MultiPoint(vec![]).into()
@@ -386,12 +389,12 @@ mod tests {
 
     #[test]
     fn convert_single_item_wkt() {
-        let wkt = Wkt::from(Point(Some(Coord {
+        let wkt = Wkt::from(Point::from_coord(Coord {
             x: 1.0,
             y: 2.0,
             z: None,
             m: None,
-        })));
+        }));
 
         let converted = geo_types::Geometry::try_from(wkt).unwrap();
         let g_point: geo_types::Point<f64> = geo_types::Point::new(1.0, 2.0);
@@ -401,19 +404,19 @@ mod tests {
 
     #[test]
     fn convert_empty_point() {
-        let point = Point(None);
+        let point = Point::empty(Dimension::XY);
         let res: Result<geo_types::Point<f64>, Error> = point.try_into();
         assert!(res.is_err());
     }
 
     #[test]
     fn convert_point() {
-        let point = Wkt::from(Point(Some(Coord {
+        let point = Wkt::from(Point::from_coord(Coord {
             x: 10.,
             y: 20.,
             z: None,
             m: None,
-        })));
+        }));
 
         let g_point: geo_types::Point<f64> = (10., 20.).into();
         assert_eq!(
@@ -424,7 +427,7 @@ mod tests {
 
     #[test]
     fn convert_empty_linestring() {
-        let w_linestring = Wkt::from(LineString(vec![]));
+        let w_linestring = Wkt::from(LineString::empty(Dimension::XY));
         let g_linestring: geo_types::LineString<f64> = geo_types::LineString(vec![]);
         assert_eq!(
             geo_types::Geometry::LineString(g_linestring),
@@ -434,7 +437,7 @@ mod tests {
 
     #[test]
     fn convert_linestring() {
-        let w_linestring: Wkt<f64> = LineString(vec![
+        let w_linestring: Wkt<f64> = LineString::from_coords([
             Coord {
                 x: 10.,
                 y: 20.,
@@ -458,7 +461,7 @@ mod tests {
 
     #[test]
     fn convert_empty_polygon() {
-        let w_polygon: Wkt<f64> = Polygon(vec![]).into();
+        let w_polygon: Wkt<f64> = Polygon::empty(Dimension::XY).into();
         let g_polygon: geo_types::Polygon<f64> =
             geo_types::Polygon::new(geo_types::LineString(vec![]), vec![]);
         assert_eq!(
@@ -469,8 +472,8 @@ mod tests {
 
     #[test]
     fn convert_polygon() {
-        let w_polygon: Wkt<f64> = Polygon(vec![
-            LineString(vec![
+        let w_polygon: Wkt<f64> = Polygon::from_rings([
+            LineString::from_coords([
                 Coord {
                     x: 0.,
                     y: 0.,
@@ -496,7 +499,7 @@ mod tests {
                     m: None,
                 },
             ]),
-            LineString(vec![
+            LineString::from_coords([
                 Coord {
                     x: 5.,
                     y: 5.,
@@ -536,7 +539,7 @@ mod tests {
 
     #[test]
     fn convert_empty_multilinestring() {
-        let w_multilinestring: Wkt<f64> = MultiLineString(vec![]).into();
+        let w_multilinestring: Wkt<f64> = MultiLineString::empty(Dimension::XY).into();
         let g_multilinestring: geo_types::MultiLineString<f64> = geo_types::MultiLineString(vec![]);
         assert_eq!(
             geo_types::Geometry::MultiLineString(g_multilinestring),
@@ -546,8 +549,8 @@ mod tests {
 
     #[test]
     fn convert_multilinestring() {
-        let w_multilinestring: Wkt<f64> = MultiLineString(vec![
-            LineString(vec![
+        let w_multilinestring: Wkt<f64> = MultiLineString::from_line_strings([
+            LineString::from_coords([
                 Coord {
                     x: 10.,
                     y: 20.,
@@ -561,7 +564,7 @@ mod tests {
                     m: None,
                 },
             ]),
-            LineString(vec![
+            LineString::from_coords([
                 Coord {
                     x: 50.,
                     y: 60.,
@@ -589,7 +592,7 @@ mod tests {
 
     #[test]
     fn convert_empty_multipoint() {
-        let w_multipoint: Wkt<f64> = MultiPoint(vec![]).into();
+        let w_multipoint: Wkt<f64> = MultiPoint::empty(Dimension::XY).into();
         let g_multipoint: geo_types::MultiPoint<f64> = geo_types::MultiPoint(vec![]);
         assert_eq!(
             geo_types::Geometry::MultiPoint(g_multipoint),
@@ -599,19 +602,19 @@ mod tests {
 
     #[test]
     fn convert_multipoint() {
-        let w_multipoint: Wkt<f64> = MultiPoint(vec![
-            Point(Some(Coord {
+        let w_multipoint: Wkt<f64> = MultiPoint::from_points([
+            Point::from_coord(Coord {
                 x: 10.,
                 y: 20.,
                 z: None,
                 m: None,
-            })),
-            Point(Some(Coord {
+            }),
+            Point::from_coord(Coord {
                 x: 30.,
                 y: 40.,
                 z: None,
                 m: None,
-            })),
+            }),
         ])
         .into();
         let g_multipoint: geo_types::MultiPoint<f64> = vec![(10., 20.), (30., 40.)].into();
@@ -623,7 +626,7 @@ mod tests {
 
     #[test]
     fn convert_empty_multipolygon() {
-        let w_multipolygon: Wkt<f64> = MultiPolygon(vec![]).into();
+        let w_multipolygon: Wkt<f64> = MultiPolygon::empty(Dimension::XY).into();
         let g_multipolygon: geo_types::MultiPolygon<f64> = geo_types::MultiPolygon(vec![]);
         assert_eq!(
             geo_types::Geometry::MultiPolygon(g_multipolygon),
@@ -633,9 +636,9 @@ mod tests {
 
     #[test]
     fn convert_multipolygon() {
-        let w_multipolygon: Wkt<f64> = MultiPolygon(vec![
-            Polygon(vec![
-                LineString(vec![
+        let w_multipolygon: Wkt<f64> = MultiPolygon::from_polygons([
+            Polygon::from_rings([
+                LineString::from_coords([
                     Coord {
                         x: 0.,
                         y: 0.,
@@ -661,7 +664,7 @@ mod tests {
                         m: None,
                     },
                 ]),
-                LineString(vec![
+                LineString::from_coords([
                     Coord {
                         x: 5.,
                         y: 5.,
@@ -688,7 +691,7 @@ mod tests {
                     },
                 ]),
             ]),
-            Polygon(vec![LineString(vec![
+            Polygon::from_rings([LineString::from_coords([
                 Coord {
                     x: 40.,
                     y: 40.,
@@ -735,7 +738,7 @@ mod tests {
 
     #[test]
     fn convert_empty_geometrycollection() {
-        let w_geometrycollection: Wkt<f64> = GeometryCollection(vec![]).into();
+        let w_geometrycollection: Wkt<f64> = GeometryCollection::empty(Dimension::XY).into();
         let g_geometrycollection: geo_types::GeometryCollection<f64> =
             geo_types::GeometryCollection(vec![]);
         assert_eq!(
@@ -746,15 +749,15 @@ mod tests {
 
     #[test]
     fn convert_geometrycollection() {
-        let w_point = Point(Some(Coord {
+        let w_point = Point::from_coord(Coord {
             x: 10.,
             y: 20.,
             z: None,
             m: None,
-        }))
+        })
         .into();
 
-        let w_linestring = LineString(vec![
+        let w_linestring = LineString::from_coords([
             Coord {
                 x: 10.,
                 y: 20.,
@@ -770,7 +773,7 @@ mod tests {
         ])
         .into();
 
-        let w_polygon = Polygon(vec![LineString(vec![
+        let w_polygon = Polygon::from_rings([LineString::from_coords([
             Coord {
                 x: 0.,
                 y: 0.,
@@ -798,8 +801,8 @@ mod tests {
         ])])
         .into();
 
-        let w_multilinestring = MultiLineString(vec![
-            LineString(vec![
+        let w_multilinestring = MultiLineString::from_line_strings([
+            LineString::from_coords([
                 Coord {
                     x: 10.,
                     y: 20.,
@@ -813,7 +816,7 @@ mod tests {
                     m: None,
                 },
             ]),
-            LineString(vec![
+            LineString::from_coords([
                 Coord {
                     x: 50.,
                     y: 60.,
@@ -830,24 +833,24 @@ mod tests {
         ])
         .into();
 
-        let w_multipoint = MultiPoint(vec![
-            Point(Some(Coord {
+        let w_multipoint = MultiPoint::from_points([
+            Point::from_coord(Coord {
                 x: 10.,
                 y: 20.,
                 z: None,
                 m: None,
-            })),
-            Point(Some(Coord {
+            }),
+            Point::from_coord(Coord {
                 x: 30.,
                 y: 40.,
                 z: None,
                 m: None,
-            })),
+            }),
         ])
         .into();
 
-        let w_multipolygon = MultiPolygon(vec![
-            Polygon(vec![LineString(vec![
+        let w_multipolygon = MultiPolygon::from_polygons([
+            Polygon::from_rings([LineString::from_coords([
                 Coord {
                     x: 0.,
                     y: 0.,
@@ -873,7 +876,7 @@ mod tests {
                     m: None,
                 },
             ])]),
-            Polygon(vec![LineString(vec![
+            Polygon::from_rings([LineString::from_coords([
                 Coord {
                     x: 40.,
                     y: 40.,
@@ -902,7 +905,7 @@ mod tests {
         ])
         .into();
 
-        let w_geometrycollection: Wkt<f64> = GeometryCollection(vec![
+        let w_geometrycollection: Wkt<f64> = GeometryCollection::from_geometries([
             w_point,
             w_multipoint,
             w_linestring,

--- a/src/geo_types_from_wkt.rs
+++ b/src/geo_types_from_wkt.rs
@@ -451,6 +451,7 @@ mod tests {
                 m: None,
             },
         ])
+        .unwrap()
         .into();
         let g_linestring: geo_types::LineString<f64> = vec![(10., 20.), (30., 40.)].into();
         assert_eq!(
@@ -498,7 +499,8 @@ mod tests {
                     z: None,
                     m: None,
                 },
-            ]),
+            ])
+            .unwrap(),
             LineString::from_coords([
                 Coord {
                     x: 5.,
@@ -524,8 +526,10 @@ mod tests {
                     z: None,
                     m: None,
                 },
-            ]),
+            ])
+            .unwrap(),
         ])
+        .unwrap()
         .into();
         let g_polygon: geo_types::Polygon<f64> = geo_types::Polygon::new(
             vec![(0., 0.), (20., 40.), (40., 0.), (0., 0.)].into(),
@@ -563,7 +567,8 @@ mod tests {
                     z: None,
                     m: None,
                 },
-            ]),
+            ])
+            .unwrap(),
             LineString::from_coords([
                 Coord {
                     x: 50.,
@@ -577,8 +582,10 @@ mod tests {
                     z: None,
                     m: None,
                 },
-            ]),
+            ])
+            .unwrap(),
         ])
+        .unwrap()
         .into();
         let g_multilinestring: geo_types::MultiLineString<f64> = geo_types::MultiLineString(vec![
             vec![(10., 20.), (30., 40.)].into(),
@@ -616,6 +623,7 @@ mod tests {
                 m: None,
             }),
         ])
+        .unwrap()
         .into();
         let g_multipoint: geo_types::MultiPoint<f64> = vec![(10., 20.), (30., 40.)].into();
         assert_eq!(
@@ -663,7 +671,8 @@ mod tests {
                         z: None,
                         m: None,
                     },
-                ]),
+                ])
+                .unwrap(),
                 LineString::from_coords([
                     Coord {
                         x: 5.,
@@ -689,8 +698,10 @@ mod tests {
                         z: None,
                         m: None,
                     },
-                ]),
-            ]),
+                ])
+                .unwrap(),
+            ])
+            .unwrap(),
             Polygon::from_rings([LineString::from_coords([
                 Coord {
                     x: 40.,
@@ -716,8 +727,11 @@ mod tests {
                     z: None,
                     m: None,
                 },
-            ])]),
+            ])
+            .unwrap()])
+            .unwrap(),
         ])
+        .unwrap()
         .into();
 
         let g_multipolygon: geo_types::MultiPolygon<f64> = geo_types::MultiPolygon(vec![
@@ -771,6 +785,7 @@ mod tests {
                 m: None,
             },
         ])
+        .unwrap()
         .into();
 
         let w_polygon = Polygon::from_rings([LineString::from_coords([
@@ -798,7 +813,9 @@ mod tests {
                 z: None,
                 m: None,
             },
-        ])])
+        ])
+        .unwrap()])
+        .unwrap()
         .into();
 
         let w_multilinestring = MultiLineString::from_line_strings([
@@ -815,7 +832,8 @@ mod tests {
                     z: None,
                     m: None,
                 },
-            ]),
+            ])
+            .unwrap(),
             LineString::from_coords([
                 Coord {
                     x: 50.,
@@ -829,8 +847,10 @@ mod tests {
                     z: None,
                     m: None,
                 },
-            ]),
+            ])
+            .unwrap(),
         ])
+        .unwrap()
         .into();
 
         let w_multipoint = MultiPoint::from_points([
@@ -847,6 +867,7 @@ mod tests {
                 m: None,
             }),
         ])
+        .unwrap()
         .into();
 
         let w_multipolygon = MultiPolygon::from_polygons([
@@ -875,7 +896,9 @@ mod tests {
                     z: None,
                     m: None,
                 },
-            ])]),
+            ])
+            .unwrap()])
+            .unwrap(),
             Polygon::from_rings([LineString::from_coords([
                 Coord {
                     x: 40.,
@@ -901,8 +924,11 @@ mod tests {
                     z: None,
                     m: None,
                 },
-            ])]),
+            ])
+            .unwrap()])
+            .unwrap(),
         ])
+        .unwrap()
         .into();
 
         let w_geometrycollection: Wkt = GeometryCollection::from_geometries([
@@ -913,6 +939,7 @@ mod tests {
             w_polygon,
             w_multipolygon,
         ])
+        .unwrap()
         .into();
 
         let g_point: geo_types::Point<f64> = (10., 20.).into();

--- a/src/geo_types_to_wkt.rs
+++ b/src/geo_types_to_wkt.rs
@@ -6,8 +6,8 @@ use crate::to_wkt::{
     write_rect, write_triangle, WriterWrapper,
 };
 use crate::types::{
-    Coord, GeometryCollection, LineString, MultiLineString, MultiPoint, MultiPolygon, Point,
-    Polygon,
+    Coord, Dimension, GeometryCollection, LineString, MultiLineString, MultiPoint, MultiPolygon,
+    Point, Polygon,
 };
 use crate::{ToWkt, Wkt};
 
@@ -345,7 +345,7 @@ where
     T: CoordNum,
 {
     let w_coords = g_points_to_w_coords(g_coords);
-    LineString::from_coords(w_coords)
+    LineString::from_coords(w_coords).unwrap_or(LineString::empty(Dimension::XY))
 }
 
 fn g_lines_to_w_lines<T>(g_lines: &[geo_types::LineString<T>]) -> Vec<LineString<T>>
@@ -391,7 +391,7 @@ where
     .chain(inner_lines.iter().map(g_linestring_to_w_linestring))
     .collect::<Vec<_>>();
 
-    Polygon::from_rings(poly_lines)
+    Polygon::from_rings(poly_lines).unwrap_or(Polygon::empty(Dimension::XY))
 }
 
 fn g_mpoint_to_w_mpoint<T>(g_mpoint: &geo_types::MultiPoint<T>) -> MultiPoint<T>
@@ -400,7 +400,7 @@ where
 {
     let geo_types::MultiPoint(g_points) = g_mpoint;
     let w_points = g_points_to_w_points(g_points);
-    MultiPoint::from_points(w_points)
+    MultiPoint::from_points(w_points).unwrap_or(MultiPoint::empty(Dimension::XY))
 }
 
 fn g_mline_to_w_mline<T>(g_mline: &geo_types::MultiLineString<T>) -> MultiLineString<T>
@@ -409,7 +409,7 @@ where
 {
     let geo_types::MultiLineString(g_lines) = g_mline;
     let w_lines = g_lines_to_w_lines(g_lines);
-    MultiLineString::from_line_strings(w_lines)
+    MultiLineString::from_line_strings(w_lines).unwrap_or(MultiLineString::empty(Dimension::XY))
 }
 
 fn g_polygons_to_w_polygons<T>(g_polygons: &[geo_types::Polygon<T>]) -> Vec<Polygon<T>>
@@ -425,7 +425,7 @@ where
 {
     let geo_types::MultiPolygon(g_polygons) = g_mpolygon;
     let w_polygons = g_polygons_to_w_polygons(g_polygons);
-    MultiPolygon::from_polygons(w_polygons)
+    MultiPolygon::from_polygons(w_polygons).unwrap_or(MultiPolygon::empty(Dimension::XY))
 }
 
 fn g_geocol_to_w_geocol<T>(g_geocol: &geo_types::GeometryCollection<T>) -> GeometryCollection<T>
@@ -434,7 +434,7 @@ where
 {
     let geo_types::GeometryCollection(g_geoms) = g_geocol;
     let w_geoms = g_geoms.iter().map(g_geom_to_w_geom).collect::<Vec<_>>();
-    GeometryCollection::from_geometries(w_geoms)
+    GeometryCollection::from_geometries(w_geoms).unwrap_or(GeometryCollection::empty(Dimension::XY))
 }
 
 fn g_geom_to_w_geom<T>(g_geom: &geo_types::Geometry<T>) -> Wkt<T>

--- a/src/geo_types_to_wkt.rs
+++ b/src/geo_types_to_wkt.rs
@@ -240,7 +240,7 @@ where
     T: CoordNum,
 {
     let coord = g_point_to_w_coord(&g_point.0);
-    Point(Some(coord))
+    Point::from_coord(coord)
 }
 
 fn g_points_to_w_coords<T>(g_points: &[geo_types::Coord<T>]) -> Vec<Coord<T>>
@@ -258,7 +258,7 @@ where
         .iter()
         .map(|p| &p.0)
         .map(g_point_to_w_coord)
-        .map(|c| Point(Some(c)))
+        .map(|c| Point::from_coord(c))
         .collect()
 }
 
@@ -282,7 +282,7 @@ where
     T: CoordNum,
 {
     let w_coords = g_points_to_w_coords(g_coords);
-    LineString(w_coords)
+    LineString::from_coords(w_coords)
 }
 
 fn g_lines_to_w_lines<T>(g_lines: &[geo_types::LineString<T>]) -> Vec<LineString<T>>
@@ -331,7 +331,7 @@ where
     let inner = g_lines_to_w_lines(inner_lines);
     poly_lines.extend(inner);
 
-    Polygon(poly_lines)
+    Polygon::from_rings(poly_lines)
 }
 
 fn g_mpoint_to_w_mpoint<T>(g_mpoint: &geo_types::MultiPoint<T>) -> MultiPoint<T>
@@ -340,7 +340,7 @@ where
 {
     let geo_types::MultiPoint(g_points) = g_mpoint;
     let w_points = g_points_to_w_points(g_points);
-    MultiPoint(w_points)
+    MultiPoint::from_points(w_points)
 }
 
 fn g_mline_to_w_mline<T>(g_mline: &geo_types::MultiLineString<T>) -> MultiLineString<T>
@@ -349,7 +349,7 @@ where
 {
     let geo_types::MultiLineString(g_lines) = g_mline;
     let w_lines = g_lines_to_w_lines(g_lines);
-    MultiLineString(w_lines)
+    MultiLineString::from_line_strings(w_lines)
 }
 
 fn g_polygons_to_w_polygons<T>(g_polygons: &[geo_types::Polygon<T>]) -> Vec<Polygon<T>>
@@ -369,7 +369,7 @@ where
 {
     let geo_types::MultiPolygon(g_polygons) = g_mpolygon;
     let w_polygons = g_polygons_to_w_polygons(g_polygons);
-    MultiPolygon(w_polygons)
+    MultiPolygon::from_polygons(w_polygons)
 }
 
 fn g_geocol_to_w_geocol<T>(g_geocol: &geo_types::GeometryCollection<T>) -> GeometryCollection<T>
@@ -382,7 +382,7 @@ where
         let w_geom = g_geom_to_w_geom(g_geom);
         w_geoms.push(w_geom);
     }
-    GeometryCollection(w_geoms)
+    GeometryCollection::from_geometries(w_geoms)
 }
 
 fn g_geom_to_w_geom<T>(g_geom: &geo_types::Geometry<T>) -> Wkt<T>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -846,7 +846,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use crate::types::{Coord, Dimension, MultiPolygon, Point};
+    use crate::types::{Dimension, MultiPolygon, Point};
     use crate::Wkt;
     use std::str::FromStr;
 
@@ -974,20 +974,6 @@ mod tests {
             Wkt::LineString(_ls) => (),
             _ => panic!("expected to be parsed as a LINESTRING"),
         };
-    }
-
-    #[test]
-    fn test_debug() {
-        let g = Wkt::Point(Point::from_coord(Coord {
-            x: 1.0,
-            y: 2.0,
-            m: None,
-            z: None,
-        }));
-        assert_eq!(
-            format!("{:?}", g),
-            "Point(Point { dim: XY, coord: Some(Coord { x: 1.0, y: 2.0, z: None, m: None }) })"
-        );
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -989,7 +989,7 @@ mod tests {
         }));
         assert_eq!(
             format!("{:?}", g),
-            "Point(Point(Some(Coord { x: 1.0, y: 2.0, z: None, m: None })))"
+            "Point(Point { dim: XY, coord: Some(Coord { x: 1.0, y: 2.0, z: None, m: None }) })"
         );
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -777,6 +777,8 @@ where
 {
     fn from_tokens(tokens: &mut PeekableTokens<T>, dim: Dimension) -> Result<Self, &'static str>;
 
+    fn new_empty(dim: Dimension) -> Self;
+
     /// The preferred top-level FromTokens API, which additionally checks for the presence of Z, M,
     /// and ZM in the token stream.
     fn from_tokens_with_header(
@@ -798,10 +800,7 @@ where
         match tokens.next().transpose()? {
             Some(Token::ParenOpen) => (),
             Some(Token::Word(ref s)) if s.eq_ignore_ascii_case("EMPTY") => {
-                // TODO: expand this to support Z EMPTY
-                // Maybe create a DefaultXY, DefaultXYZ trait etc for each geometry type, and then
-                // here match on the dim to decide which default trait to use.
-                return Ok(Default::default());
+                return Ok(Self::new_empty(dim));
             }
             _ => return Err("Missing open parenthesis for type"),
         };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -180,15 +180,16 @@ impl<T> Wkt<T>
 where
     T: WktNum,
 {
-    pub(crate) fn dimension(&self) -> Dimension {
+    /// Return the dimension of this geometry.
+    pub fn dimension(&self) -> Dimension {
         match self {
-            Self::Point(g) => g.dim,
-            Self::LineString(g) => g.dim,
-            Self::Polygon(g) => g.dim,
-            Self::MultiPoint(g) => g.dim,
-            Self::MultiLineString(g) => g.dim,
-            Self::MultiPolygon(g) => g.dim,
-            Self::GeometryCollection(g) => g.dim,
+            Self::Point(g) => g.dimension(),
+            Self::LineString(g) => g.dimension(),
+            Self::Polygon(g) => g.dimension(),
+            Self::MultiPoint(g) => g.dimension(),
+            Self::MultiLineString(g) => g.dimension(),
+            Self::MultiPolygon(g) => g.dimension(),
+            Self::GeometryCollection(g) => g.dimension(),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -180,7 +180,7 @@ impl<T> Wkt<T>
 where
     T: WktNum,
 {
-    /// Return the dimension of this geometry.
+    /// Return the [Dimension] of this geometry.
     pub fn dimension(&self) -> Dimension {
         match self {
             Self::Point(g) => g.dimension(),

--- a/src/types/coord.rs
+++ b/src/types/coord.rs
@@ -29,7 +29,7 @@ pub struct Coord<T: WktNum = f64> {
 }
 
 impl<T: WktNum> Coord<T> {
-    /// Return the dimension of this coord.
+    /// Return the [Dimension] of this coord.
     pub fn dimension(&self) -> Dimension {
         match (self.z.is_some(), self.m.is_some()) {
             (true, true) => Dimension::XYZM,

--- a/src/types/coord.rs
+++ b/src/types/coord.rs
@@ -90,6 +90,10 @@ where
 
         Ok(Coord { x, y, z, m })
     }
+
+    fn new_empty(_dim: Dimension) -> Self {
+        unreachable!("empty coord does not exist in WKT")
+    }
 }
 
 impl<T: WktNum> CoordTrait for Coord<T> {

--- a/src/types/coord.rs
+++ b/src/types/coord.rs
@@ -19,6 +19,7 @@ use crate::types::Dimension;
 use crate::{FromTokens, WktNum};
 use std::str::FromStr;
 
+/// A parsed coordinate.
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct Coord<T: WktNum = f64> {
     pub x: T,
@@ -28,7 +29,8 @@ pub struct Coord<T: WktNum = f64> {
 }
 
 impl<T: WktNum> Coord<T> {
-    pub(crate) fn dimension(&self) -> Dimension {
+    /// Return the dimension of this coord.
+    pub fn dimension(&self) -> Dimension {
         match (self.z.is_some(), self.m.is_some()) {
             (true, true) => Dimension::XYZM,
             (true, false) => Dimension::XYZ,

--- a/src/types/coord.rs
+++ b/src/types/coord.rs
@@ -30,6 +30,17 @@ where
     pub m: Option<T>,
 }
 
+impl<T: WktNum> Coord<T> {
+    pub(crate) fn dimension(&self) -> Dimension {
+        match (self.z.is_some(), self.m.is_some()) {
+            (true, true) => Dimension::XYZM,
+            (true, false) => Dimension::XYZ,
+            (false, true) => Dimension::XYM,
+            (false, false) => Dimension::XY,
+        }
+    }
+}
+
 impl<T> FromTokens<T> for Coord<T>
 where
     T: WktNum + FromStr + Default,
@@ -85,12 +96,7 @@ impl<T: WktNum> CoordTrait for Coord<T> {
     type T = T;
 
     fn dim(&self) -> geo_traits::Dimensions {
-        match (self.z.is_some(), self.m.is_some()) {
-            (true, true) => geo_traits::Dimensions::Xyzm,
-            (true, false) => geo_traits::Dimensions::Xyz,
-            (false, true) => geo_traits::Dimensions::Xym,
-            (false, false) => geo_traits::Dimensions::Xy,
-        }
+        self.dimension().into()
     }
 
     fn x(&self) -> Self::T {
@@ -132,12 +138,7 @@ impl<T: WktNum> CoordTrait for &Coord<T> {
     type T = T;
 
     fn dim(&self) -> geo_traits::Dimensions {
-        match (self.z.is_some(), self.m.is_some()) {
-            (true, true) => geo_traits::Dimensions::Xyzm,
-            (true, false) => geo_traits::Dimensions::Xyz,
-            (false, true) => geo_traits::Dimensions::Xym,
-            (false, false) => geo_traits::Dimensions::Xy,
-        }
+        self.dimension().into()
     }
 
     fn x(&self) -> Self::T {

--- a/src/types/dimension.rs
+++ b/src/types/dimension.rs
@@ -8,3 +8,14 @@ pub enum Dimension {
     XYM,
     XYZM,
 }
+
+impl From<Dimension> for geo_traits::Dimensions {
+    fn from(value: Dimension) -> Self {
+        match value {
+            Dimension::XY => Self::Xy,
+            Dimension::XYZ => Self::Xyz,
+            Dimension::XYM => Self::Xym,
+            Dimension::XYZM => Self::Xyzm,
+        }
+    }
+}

--- a/src/types/geometrycollection.rs
+++ b/src/types/geometrycollection.rs
@@ -74,9 +74,6 @@ impl<T> FromTokens<T> for GeometryCollection<T>
 where
     T: WktNum + FromStr + Default,
 {
-    // Unsure if the dimension should be used in parsing GeometryCollection; is it
-    // GEOMETRYCOLLECTION ( POINT Z (...) , POINT ZM (...))
-    // or does a geometry collection have a known dimension?
     fn from_tokens(tokens: &mut PeekableTokens<T>, dim: Dimension) -> Result<Self, &'static str> {
         let mut items = Vec::new();
 
@@ -177,29 +174,28 @@ mod tests {
 
     #[test]
     fn write_empty_geometry_collection() {
-        let geometry_collection: GeometryCollection<f64> =
-            GeometryCollection::new(vec![], Dimension::XY);
+        let geometry_collection: GeometryCollection<f64> = GeometryCollection::empty(Dimension::XY);
         assert_eq!(
             "GEOMETRYCOLLECTION EMPTY",
             format!("{}", geometry_collection)
         );
 
         let geometry_collection: GeometryCollection<f64> =
-            GeometryCollection::new(vec![], Dimension::XYZ);
+            GeometryCollection::empty(Dimension::XYZ);
         assert_eq!(
             "GEOMETRYCOLLECTION Z EMPTY",
             format!("{}", geometry_collection)
         );
 
         let geometry_collection: GeometryCollection<f64> =
-            GeometryCollection::new(vec![], Dimension::XYM);
+            GeometryCollection::empty(Dimension::XYM);
         assert_eq!(
             "GEOMETRYCOLLECTION M EMPTY",
             format!("{}", geometry_collection)
         );
 
         let geometry_collection: GeometryCollection<f64> =
-            GeometryCollection::new(vec![], Dimension::XYZM);
+            GeometryCollection::empty(Dimension::XYZM);
         assert_eq!(
             "GEOMETRYCOLLECTION ZM EMPTY",
             format!("{}", geometry_collection)

--- a/src/types/geometrycollection.rs
+++ b/src/types/geometrycollection.rs
@@ -99,6 +99,10 @@ where
 
         Ok(GeometryCollection { geoms: items, dim })
     }
+
+    fn new_empty(dim: Dimension) -> Self {
+        Self::empty(dim)
+    }
 }
 
 impl<T: WktNum> GeometryCollectionTrait for GeometryCollection<T> {
@@ -170,6 +174,45 @@ mod tests {
             _ => unreachable!(),
         };
         assert_eq!(2, geoms.len());
+    }
+
+    #[test]
+    fn parse_empty_geometrycollection() {
+        let wkt: Wkt<f64> = Wkt::from_str("GEOMETRYCOLLECTION EMPTY").ok().unwrap();
+        match wkt {
+            Wkt::GeometryCollection(GeometryCollection { geoms, dim }) => {
+                assert!(geoms.is_empty());
+                assert_eq!(dim, Dimension::XY);
+            }
+            _ => unreachable!(),
+        };
+
+        let wkt: Wkt<f64> = Wkt::from_str("GEOMETRYCOLLECTION Z EMPTY").ok().unwrap();
+        match wkt {
+            Wkt::GeometryCollection(GeometryCollection { geoms, dim }) => {
+                assert!(geoms.is_empty());
+                assert_eq!(dim, Dimension::XYZ);
+            }
+            _ => unreachable!(),
+        };
+
+        let wkt: Wkt<f64> = Wkt::from_str("GEOMETRYCOLLECTION M EMPTY").ok().unwrap();
+        match wkt {
+            Wkt::GeometryCollection(GeometryCollection { geoms, dim }) => {
+                assert!(geoms.is_empty());
+                assert_eq!(dim, Dimension::XYM);
+            }
+            _ => unreachable!(),
+        };
+
+        let wkt: Wkt<f64> = Wkt::from_str("GEOMETRYCOLLECTION ZM EMPTY").ok().unwrap();
+        match wkt {
+            Wkt::GeometryCollection(GeometryCollection { geoms, dim }) => {
+                assert!(geoms.is_empty());
+                assert_eq!(dim, Dimension::XYZM);
+            }
+            _ => unreachable!(),
+        };
     }
 
     #[test]

--- a/src/types/geometrycollection.rs
+++ b/src/types/geometrycollection.rs
@@ -21,16 +21,17 @@ use crate::{FromTokens, Wkt, WktNum};
 use std::fmt;
 use std::str::FromStr;
 
+/// A parsed GeometryCollection.
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct GeometryCollection<T: WktNum = f64> {
-    pub(crate) dim: Dimension,
     pub(crate) geoms: Vec<Wkt<T>>,
+    pub(crate) dim: Dimension,
 }
 
 impl<T: WktNum> GeometryCollection<T> {
     /// Create a new GeometryCollection from a sequence of [Wkt].
     pub fn new(geoms: Vec<Wkt<T>>, dim: Dimension) -> Self {
-        Self { dim, geoms }
+        Self { geoms, dim }
     }
 
     /// Create a new empty GeometryCollection.
@@ -50,6 +51,16 @@ impl<T: WktNum> GeometryCollection<T> {
         let geoms = geoms.into_iter().collect::<Vec<_>>();
         let dim = geoms[0].dimension();
         Self::new(geoms, dim)
+    }
+
+    /// Return the dimension of this geometry.
+    pub fn dimension(&self) -> Dimension {
+        self.dim
+    }
+
+    /// Consume self and return the inner parts.
+    pub fn into_inner(self) -> (Vec<Wkt<T>>, Dimension) {
+        (self.geoms, self.dim)
     }
 }
 

--- a/src/types/geometrycollection.rs
+++ b/src/types/geometrycollection.rs
@@ -179,9 +179,29 @@ mod tests {
     fn write_empty_geometry_collection() {
         let geometry_collection: GeometryCollection<f64> =
             GeometryCollection::new(vec![], Dimension::XY);
-
         assert_eq!(
             "GEOMETRYCOLLECTION EMPTY",
+            format!("{}", geometry_collection)
+        );
+
+        let geometry_collection: GeometryCollection<f64> =
+            GeometryCollection::new(vec![], Dimension::XYZ);
+        assert_eq!(
+            "GEOMETRYCOLLECTION Z EMPTY",
+            format!("{}", geometry_collection)
+        );
+
+        let geometry_collection: GeometryCollection<f64> =
+            GeometryCollection::new(vec![], Dimension::XYM);
+        assert_eq!(
+            "GEOMETRYCOLLECTION M EMPTY",
+            format!("{}", geometry_collection)
+        );
+
+        let geometry_collection: GeometryCollection<f64> =
+            GeometryCollection::new(vec![], Dimension::XYZM);
+        assert_eq!(
+            "GEOMETRYCOLLECTION ZM EMPTY",
             format!("{}", geometry_collection)
         );
     }

--- a/src/types/geometrycollection.rs
+++ b/src/types/geometrycollection.rs
@@ -28,6 +28,7 @@ pub struct GeometryCollection<T: WktNum> {
 }
 
 impl<T: WktNum> GeometryCollection<T> {
+    /// Create a new GeometryCollection from a sequence of [Wkt].
     pub fn new(geoms: Vec<Wkt<T>>, dim: Dimension) -> Self {
         Self { dim, geoms }
     }

--- a/src/types/geometrycollection.rs
+++ b/src/types/geometrycollection.rs
@@ -158,7 +158,10 @@ mod tests {
             .ok()
             .unwrap();
         let geoms = match wkt {
-            Wkt::GeometryCollection(GeometryCollection { geoms, dim: _ }) => geoms,
+            Wkt::GeometryCollection(GeometryCollection { geoms, dim }) => {
+                assert_eq!(dim, Dimension::XY);
+                geoms
+            }
             _ => unreachable!(),
         };
         assert_eq!(1, geoms.len());
@@ -170,7 +173,10 @@ mod tests {
             .ok()
             .unwrap();
         let geoms = match wkt {
-            Wkt::GeometryCollection(GeometryCollection { geoms, dim: _ }) => geoms,
+            Wkt::GeometryCollection(GeometryCollection { geoms, dim }) => {
+                assert_eq!(dim, Dimension::XY);
+                geoms
+            }
             _ => unreachable!(),
         };
         assert_eq!(2, geoms.len());

--- a/src/types/geometrycollection.rs
+++ b/src/types/geometrycollection.rs
@@ -53,9 +53,14 @@ impl<T: WktNum> GeometryCollection<T> {
         Self::new(geoms, dim)
     }
 
-    /// Return the dimension of this geometry.
+    /// Return the [Dimension] of this geometry.
     pub fn dimension(&self) -> Dimension {
         self.dim
+    }
+
+    /// Access the underlying [Wkt] geometries.
+    pub fn geometries(&self) -> &[Wkt<T>] {
+        &self.geoms
     }
 
     /// Consume self and return the inner parts.

--- a/src/types/geometrycollection.rs
+++ b/src/types/geometrycollection.rs
@@ -77,7 +77,7 @@ where
     // Unsure if the dimension should be used in parsing GeometryCollection; is it
     // GEOMETRYCOLLECTION ( POINT Z (...) , POINT ZM (...))
     // or does a geometry collection have a known dimension?
-    fn from_tokens(tokens: &mut PeekableTokens<T>, _dim: Dimension) -> Result<Self, &'static str> {
+    fn from_tokens(tokens: &mut PeekableTokens<T>, dim: Dimension) -> Result<Self, &'static str> {
         let mut items = Vec::new();
 
         let word = match tokens.next().transpose()? {
@@ -100,7 +100,7 @@ where
             items.push(item);
         }
 
-        Ok(GeometryCollection(items))
+        Ok(GeometryCollection { geoms: items, dim })
     }
 }
 

--- a/src/types/linestring.rs
+++ b/src/types/linestring.rs
@@ -70,6 +70,10 @@ where
         let result = FromTokens::comma_many(<Coord<T> as FromTokens<T>>::from_tokens, tokens, dim);
         result.map(|coords| LineString { coords, dim })
     }
+
+    fn new_empty(dim: Dimension) -> Self {
+        Self::empty(dim)
+    }
 }
 
 impl<T> fmt::Display for LineString<T>

--- a/src/types/linestring.rs
+++ b/src/types/linestring.rs
@@ -23,7 +23,16 @@ use std::fmt;
 use std::str::FromStr;
 
 #[derive(Clone, Debug, Default, PartialEq)]
-pub struct LineString<T: WktNum>(pub Vec<Coord<T>>);
+pub struct LineString<T: WktNum> {
+    dim: Dimension,
+    coords: Vec<Coord<T>>,
+}
+
+impl<T: WktNum> LineString<T> {
+    pub fn new(coords: Vec<Coord<T>>, dim: Dimension) -> Self {
+        LineString { dim, coords }
+    }
+}
 
 impl<T> From<LineString<T>> for Wkt<T>
 where
@@ -61,20 +70,15 @@ impl<T: WktNum> LineStringTrait for LineString<T> {
         Self: 'a;
 
     fn dim(&self) -> geo_traits::Dimensions {
-        // TODO: infer dimension from empty WKT
-        if self.0.is_empty() {
-            geo_traits::Dimensions::Xy
-        } else {
-            self.0[0].dim()
-        }
+        self.dim.into()
     }
 
     fn num_coords(&self) -> usize {
-        self.0.len()
+        self.coords.len()
     }
 
     unsafe fn coord_unchecked(&self, i: usize) -> Self::CoordType<'_> {
-        self.0.get_unchecked(i)
+        self.coords.get_unchecked(i)
     }
 }
 
@@ -86,20 +90,15 @@ impl<T: WktNum> LineStringTrait for &LineString<T> {
         Self: 'a;
 
     fn dim(&self) -> geo_traits::Dimensions {
-        // TODO: infer dimension from empty WKT
-        if self.0.is_empty() {
-            geo_traits::Dimensions::Xy
-        } else {
-            self.0[0].dim()
-        }
+        self.dim.into()
     }
 
     fn num_coords(&self) -> usize {
-        self.0.len()
+        self.coords.len()
     }
 
     unsafe fn coord_unchecked(&self, i: usize) -> Self::CoordType<'_> {
-        self.0.get_unchecked(i)
+        self.coords.get_unchecked(i)
     }
 }
 

--- a/src/types/linestring.rs
+++ b/src/types/linestring.rs
@@ -136,7 +136,10 @@ mod tests {
     fn basic_linestring() {
         let wkt: Wkt<f64> = Wkt::from_str("LINESTRING (10 -20, -0 -0.5)").ok().unwrap();
         let coords = match wkt {
-            Wkt::LineString(LineString { coords, dim: _ }) => coords,
+            Wkt::LineString(LineString { coords, dim }) => {
+                assert_eq!(dim, Dimension::XY);
+                coords
+            }
             _ => unreachable!(),
         };
         assert_eq!(2, coords.len());
@@ -158,7 +161,10 @@ mod tests {
             .ok()
             .unwrap();
         let coords = match wkt {
-            Wkt::LineString(LineString { coords, dim: _ }) => coords,
+            Wkt::LineString(LineString { coords, dim }) => {
+                assert_eq!(dim, Dimension::XYZ);
+                coords
+            }
             _ => unreachable!(),
         };
         assert_eq!(2, coords.len());
@@ -180,7 +186,10 @@ mod tests {
             .ok()
             .unwrap();
         let coords = match wkt {
-            Wkt::LineString(LineString { coords, dim: _ }) => coords,
+            Wkt::LineString(LineString { coords, dim }) => {
+                assert_eq!(dim, Dimension::XYM);
+                coords
+            }
             _ => unreachable!(),
         };
         assert_eq!(2, coords.len());
@@ -202,7 +211,10 @@ mod tests {
             .ok()
             .unwrap();
         let coords = match wkt {
-            Wkt::LineString(LineString { coords, dim: _ }) => coords,
+            Wkt::LineString(LineString { coords, dim }) => {
+                assert_eq!(dim, Dimension::XYZM);
+                coords
+            }
             _ => unreachable!(),
         };
         assert_eq!(2, coords.len());
@@ -224,7 +236,10 @@ mod tests {
             .ok()
             .unwrap();
         let coords = match wkt {
-            Wkt::LineString(LineString { coords, dim: _ }) => coords,
+            Wkt::LineString(LineString { coords, dim }) => {
+                assert_eq!(dim, Dimension::XYZM);
+                coords
+            }
             _ => unreachable!(),
         };
         assert_eq!(2, coords.len());

--- a/src/types/linestring.rs
+++ b/src/types/linestring.rs
@@ -22,10 +22,11 @@ use crate::{FromTokens, Wkt, WktNum};
 use std::fmt;
 use std::str::FromStr;
 
+/// A parsed LineString.
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct LineString<T: WktNum = f64> {
-    pub(crate) dim: Dimension,
     pub(crate) coords: Vec<Coord<T>>,
+    pub(crate) dim: Dimension,
 }
 
 impl<T: WktNum> LineString<T> {
@@ -51,6 +52,16 @@ impl<T: WktNum> LineString<T> {
         let coords = coords.into_iter().collect::<Vec<_>>();
         let dim = coords[0].dimension();
         Self::new(coords, dim)
+    }
+
+    /// Return the dimension of this geometry.
+    pub fn dimension(&self) -> Dimension {
+        self.dim
+    }
+
+    /// Consume self and return the inner parts.
+    pub fn into_inner(self) -> (Vec<Coord<T>>, Dimension) {
+        (self.coords, self.dim)
     }
 }
 

--- a/src/types/linestring.rs
+++ b/src/types/linestring.rs
@@ -29,6 +29,7 @@ pub struct LineString<T: WktNum> {
 }
 
 impl<T: WktNum> LineString<T> {
+    /// Create a new LineString from a sequence of [Coord] and known [Dimension].
     pub fn new(coords: Vec<Coord<T>>, dim: Dimension) -> Self {
         LineString { dim, coords }
     }

--- a/src/types/linestring.rs
+++ b/src/types/linestring.rs
@@ -54,9 +54,14 @@ impl<T: WktNum> LineString<T> {
         Self::new(coords, dim)
     }
 
-    /// Return the dimension of this geometry.
+    /// Return the [Dimension] of this geometry.
     pub fn dimension(&self) -> Dimension {
         self.dim
+    }
+
+    /// Access the coordinates of this LineString.
+    pub fn coords(&self) -> &[Coord<T>] {
+        &self.coords
     }
 
     /// Consume self and return the inner parts.

--- a/src/types/linestring.rs
+++ b/src/types/linestring.rs
@@ -68,7 +68,7 @@ where
 {
     fn from_tokens(tokens: &mut PeekableTokens<T>, dim: Dimension) -> Result<Self, &'static str> {
         let result = FromTokens::comma_many(<Coord<T> as FromTokens<T>>::from_tokens, tokens, dim);
-        result.map(LineString)
+        result.map(|coords| LineString { coords, dim })
     }
 }
 

--- a/src/types/linestring.rs
+++ b/src/types/linestring.rs
@@ -239,8 +239,16 @@ mod tests {
     #[test]
     fn write_empty_linestring() {
         let linestring: LineString<f64> = LineString::empty(Dimension::XY);
-
         assert_eq!("LINESTRING EMPTY", format!("{}", linestring));
+
+        let linestring: LineString<f64> = LineString::empty(Dimension::XYZ);
+        assert_eq!("LINESTRING Z EMPTY", format!("{}", linestring));
+
+        let linestring: LineString<f64> = LineString::empty(Dimension::XYM);
+        assert_eq!("LINESTRING M EMPTY", format!("{}", linestring));
+
+        let linestring: LineString<f64> = LineString::empty(Dimension::XYZM);
+        assert_eq!("LINESTRING ZM EMPTY", format!("{}", linestring));
     }
 
     #[test]

--- a/src/types/linestring.rs
+++ b/src/types/linestring.rs
@@ -237,6 +237,45 @@ mod tests {
     }
 
     #[test]
+    fn parse_empty_linestring() {
+        let wkt: Wkt<f64> = Wkt::from_str("LINESTRING EMPTY").ok().unwrap();
+        match wkt {
+            Wkt::LineString(LineString { coords, dim }) => {
+                assert!(coords.is_empty());
+                assert_eq!(dim, Dimension::XY);
+            }
+            _ => unreachable!(),
+        };
+
+        let wkt: Wkt<f64> = Wkt::from_str("LINESTRING Z EMPTY").ok().unwrap();
+        match wkt {
+            Wkt::LineString(LineString { coords, dim }) => {
+                assert!(coords.is_empty());
+                assert_eq!(dim, Dimension::XYZ);
+            }
+            _ => unreachable!(),
+        };
+
+        let wkt: Wkt<f64> = Wkt::from_str("LINESTRING M EMPTY").ok().unwrap();
+        match wkt {
+            Wkt::LineString(LineString { coords, dim }) => {
+                assert!(coords.is_empty());
+                assert_eq!(dim, Dimension::XYM);
+            }
+            _ => unreachable!(),
+        };
+
+        let wkt: Wkt<f64> = Wkt::from_str("LINESTRING ZM EMPTY").ok().unwrap();
+        match wkt {
+            Wkt::LineString(LineString { coords, dim }) => {
+                assert!(coords.is_empty());
+                assert_eq!(dim, Dimension::XYZM);
+            }
+            _ => unreachable!(),
+        };
+    }
+
+    #[test]
     fn write_empty_linestring() {
         let linestring: LineString<f64> = LineString::empty(Dimension::XY);
         assert_eq!("LINESTRING EMPTY", format!("{}", linestring));

--- a/src/types/multilinestring.rs
+++ b/src/types/multilinestring.rs
@@ -23,7 +23,16 @@ use std::fmt;
 use std::str::FromStr;
 
 #[derive(Clone, Debug, Default, PartialEq)]
-pub struct MultiLineString<T: WktNum>(pub Vec<LineString<T>>);
+pub struct MultiLineString<T: WktNum> {
+    dim: Dimension,
+    line_strings: Vec<LineString<T>>,
+}
+
+impl<T: WktNum> MultiLineString<T> {
+    pub fn new(line_strings: Vec<LineString<T>>, dim: Dimension) -> Self {
+        MultiLineString { dim, line_strings }
+    }
+}
 
 impl<T> From<MultiLineString<T>> for Wkt<T>
 where
@@ -65,20 +74,15 @@ impl<T: WktNum> MultiLineStringTrait for MultiLineString<T> {
         Self: 'a;
 
     fn dim(&self) -> geo_traits::Dimensions {
-        // TODO: infer dimension from empty WKT
-        if self.0.is_empty() {
-            geo_traits::Dimensions::Xy
-        } else {
-            self.0[0].dim()
-        }
+        self.dim.into()
     }
 
     fn num_line_strings(&self) -> usize {
-        self.0.len()
+        self.line_strings.len()
     }
 
     unsafe fn line_string_unchecked(&self, i: usize) -> Self::LineStringType<'_> {
-        self.0.get_unchecked(i)
+        self.line_strings.get_unchecked(i)
     }
 }
 
@@ -90,20 +94,15 @@ impl<T: WktNum> MultiLineStringTrait for &MultiLineString<T> {
         Self: 'a;
 
     fn dim(&self) -> geo_traits::Dimensions {
-        // TODO: infer dimension from empty WKT
-        if self.0.is_empty() {
-            geo_traits::Dimensions::Xy
-        } else {
-            self.0[0].dim()
-        }
+        self.dim.into()
     }
 
     fn num_line_strings(&self) -> usize {
-        self.0.len()
+        self.line_strings.len()
     }
 
     unsafe fn line_string_unchecked(&self, i: usize) -> Self::LineStringType<'_> {
-        self.0.get_unchecked(i)
+        self.line_strings.get_unchecked(i)
     }
 }
 

--- a/src/types/multilinestring.rs
+++ b/src/types/multilinestring.rs
@@ -54,9 +54,14 @@ impl<T: WktNum> MultiLineString<T> {
         Self::new(line_strings, dim)
     }
 
-    /// Return the dimension of this geometry.
+    /// Return the [Dimension] of this geometry.
     pub fn dimension(&self) -> Dimension {
         self.dim
+    }
+
+    /// Access the inner line strings.
+    pub fn line_strings(&self) -> &[LineString<T>] {
+        &self.line_strings
     }
 
     /// Consume self and return the inner parts.

--- a/src/types/multilinestring.rs
+++ b/src/types/multilinestring.rs
@@ -29,6 +29,7 @@ pub struct MultiLineString<T: WktNum> {
 }
 
 impl<T: WktNum> MultiLineString<T> {
+    /// Create a new LineString from a sequence of [LineString] and known [Dimension].
     pub fn new(line_strings: Vec<LineString<T>>, dim: Dimension) -> Self {
         MultiLineString { dim, line_strings }
     }

--- a/src/types/multilinestring.rs
+++ b/src/types/multilinestring.rs
@@ -150,8 +150,16 @@ mod tests {
     #[test]
     fn write_empty_multilinestring() {
         let multilinestring: MultiLineString<f64> = MultiLineString::empty(Dimension::XY);
-
         assert_eq!("MULTILINESTRING EMPTY", format!("{}", multilinestring));
+
+        let multilinestring: MultiLineString<f64> = MultiLineString::empty(Dimension::XYZ);
+        assert_eq!("MULTILINESTRING Z EMPTY", format!("{}", multilinestring));
+
+        let multilinestring: MultiLineString<f64> = MultiLineString::empty(Dimension::XYM);
+        assert_eq!("MULTILINESTRING M EMPTY", format!("{}", multilinestring));
+
+        let multilinestring: MultiLineString<f64> = MultiLineString::empty(Dimension::XYZM);
+        assert_eq!("MULTILINESTRING ZM EMPTY", format!("{}", multilinestring));
     }
 
     #[test]

--- a/src/types/multilinestring.rs
+++ b/src/types/multilinestring.rs
@@ -81,7 +81,7 @@ where
             tokens,
             dim,
         );
-        result.map(MultiLineString)
+        result.map(|line_strings| MultiLineString { line_strings, dim })
     }
 }
 

--- a/src/types/multilinestring.rs
+++ b/src/types/multilinestring.rs
@@ -142,10 +142,10 @@ mod tests {
             .ok()
             .unwrap();
         let lines = match wkt {
-            Wkt::MultiLineString(MultiLineString {
-                line_strings,
-                dim: _,
-            }) => line_strings,
+            Wkt::MultiLineString(MultiLineString { line_strings, dim }) => {
+                assert_eq!(dim, Dimension::XY);
+                line_strings
+            }
             _ => unreachable!(),
         };
         assert_eq!(2, lines.len());

--- a/src/types/multilinestring.rs
+++ b/src/types/multilinestring.rs
@@ -83,6 +83,10 @@ where
         );
         result.map(|line_strings| MultiLineString { line_strings, dim })
     }
+
+    fn new_empty(dim: Dimension) -> Self {
+        Self::empty(dim)
+    }
 }
 
 impl<T: WktNum> MultiLineStringTrait for MultiLineString<T> {
@@ -145,6 +149,45 @@ mod tests {
             _ => unreachable!(),
         };
         assert_eq!(2, lines.len());
+    }
+
+    #[test]
+    fn parse_empty_multilinestring() {
+        let wkt: Wkt<f64> = Wkt::from_str("MULTILINESTRING EMPTY").ok().unwrap();
+        match wkt {
+            Wkt::MultiLineString(MultiLineString { line_strings, dim }) => {
+                assert!(line_strings.is_empty());
+                assert_eq!(dim, Dimension::XY);
+            }
+            _ => unreachable!(),
+        };
+
+        let wkt: Wkt<f64> = Wkt::from_str("MULTILINESTRING Z EMPTY").ok().unwrap();
+        match wkt {
+            Wkt::MultiLineString(MultiLineString { line_strings, dim }) => {
+                assert!(line_strings.is_empty());
+                assert_eq!(dim, Dimension::XYZ);
+            }
+            _ => unreachable!(),
+        };
+
+        let wkt: Wkt<f64> = Wkt::from_str("MULTILINESTRING M EMPTY").ok().unwrap();
+        match wkt {
+            Wkt::MultiLineString(MultiLineString { line_strings, dim }) => {
+                assert!(line_strings.is_empty());
+                assert_eq!(dim, Dimension::XYM);
+            }
+            _ => unreachable!(),
+        };
+
+        let wkt: Wkt<f64> = Wkt::from_str("MULTILINESTRING ZM EMPTY").ok().unwrap();
+        match wkt {
+            Wkt::MultiLineString(MultiLineString { line_strings, dim }) => {
+                assert!(line_strings.is_empty());
+                assert_eq!(dim, Dimension::XYZM);
+            }
+            _ => unreachable!(),
+        };
     }
 
     #[test]

--- a/src/types/multilinestring.rs
+++ b/src/types/multilinestring.rs
@@ -22,10 +22,11 @@ use crate::{FromTokens, Wkt, WktNum};
 use std::fmt;
 use std::str::FromStr;
 
+/// A parsed MultiLineString.
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct MultiLineString<T: WktNum = f64> {
-    pub(crate) dim: Dimension,
     pub(crate) line_strings: Vec<LineString<T>>,
+    pub(crate) dim: Dimension,
 }
 
 impl<T: WktNum> MultiLineString<T> {
@@ -49,8 +50,18 @@ impl<T: WktNum> MultiLineString<T> {
     /// If the input iterator is empty.
     pub fn from_line_strings(line_strings: impl IntoIterator<Item = LineString<T>>) -> Self {
         let line_strings = line_strings.into_iter().collect::<Vec<_>>();
-        let dim = line_strings[0].dim;
+        let dim = line_strings[0].dimension();
         Self::new(line_strings, dim)
+    }
+
+    /// Return the dimension of this geometry.
+    pub fn dimension(&self) -> Dimension {
+        self.dim
+    }
+
+    /// Consume self and return the inner parts.
+    pub fn into_inner(self) -> (Vec<LineString<T>>, Dimension) {
+        (self.line_strings, self.dim)
     }
 }
 

--- a/src/types/multilinestring.rs
+++ b/src/types/multilinestring.rs
@@ -14,6 +14,7 @@
 
 use geo_traits::MultiLineStringTrait;
 
+use crate::error::Error;
 use crate::to_wkt::write_multi_linestring;
 use crate::tokenizer::PeekableTokens;
 use crate::types::linestring::LineString;
@@ -45,13 +46,22 @@ impl<T: WktNum> MultiLineString<T> {
     /// This will infer the dimension from the first line string, and will not validate that all
     /// line strings have the same dimension.
     ///
-    /// ## Panics
+    /// ## Errors
     ///
     /// If the input iterator is empty.
-    pub fn from_line_strings(line_strings: impl IntoIterator<Item = LineString<T>>) -> Self {
+    ///
+    /// To handle empty input iterators, consider calling `unwrap_or` on the result and defaulting
+    /// to an [empty][Self::empty] geometry with specified dimension.
+    pub fn from_line_strings(
+        line_strings: impl IntoIterator<Item = LineString<T>>,
+    ) -> Result<Self, Error> {
         let line_strings = line_strings.into_iter().collect::<Vec<_>>();
-        let dim = line_strings[0].dimension();
-        Self::new(line_strings, dim)
+        if line_strings.is_empty() {
+            Err(Error::UnknownDimension)
+        } else {
+            let dim = line_strings[0].dimension();
+            Ok(Self::new(line_strings, dim))
+        }
     }
 
     /// Return the [Dimension] of this geometry.
@@ -238,7 +248,8 @@ mod tests {
                     z: None,
                     m: None,
                 },
-            ]),
+            ])
+            .unwrap(),
             LineString::from_coords([
                 Coord {
                     x: 50.5,
@@ -252,8 +263,10 @@ mod tests {
                     z: None,
                     m: None,
                 },
-            ]),
-        ]);
+            ])
+            .unwrap(),
+        ])
+        .unwrap();
 
         assert_eq!(
             "MULTILINESTRING((10.1 20.2,30.3 40.4),(50.5 60.6,70.7 80.8))",

--- a/src/types/multipoint.rs
+++ b/src/types/multipoint.rs
@@ -193,7 +193,10 @@ mod tests {
     fn postgis_style_multipoint() {
         let wkt: Wkt<f64> = Wkt::from_str("MULTIPOINT (8 4, 4 0)").unwrap();
         let points = match wkt {
-            Wkt::MultiPoint(MultiPoint { points, dim: _ }) => points,
+            Wkt::MultiPoint(MultiPoint { points, dim }) => {
+                assert_eq!(dim, Dimension::XY);
+                points
+            }
             _ => unreachable!(),
         };
         assert_eq!(2, points.len());
@@ -203,20 +206,13 @@ mod tests {
     fn mixed_parens_multipoint() {
         let wkt: Wkt<f64> = Wkt::from_str("MULTIPOINT (8 4, (4 0))").unwrap();
         let points = match wkt {
-            Wkt::MultiPoint(MultiPoint { points, dim: _ }) => points,
+            Wkt::MultiPoint(MultiPoint { points, dim }) => {
+                assert_eq!(dim, Dimension::XY);
+                points
+            }
             _ => unreachable!(),
         };
         assert_eq!(2, points.len());
-    }
-
-    #[test]
-    fn empty_multipoint() {
-        let wkt: Wkt<f64> = Wkt::from_str("MULTIPOINT EMPTY").unwrap();
-        let points = match wkt {
-            Wkt::MultiPoint(MultiPoint { points, dim: _ }) => points,
-            _ => unreachable!(),
-        };
-        assert_eq!(0, points.len());
     }
 
     #[test]

--- a/src/types/multipoint.rs
+++ b/src/types/multipoint.rs
@@ -218,8 +218,16 @@ mod tests {
     #[test]
     fn write_empty_multipoint() {
         let multipoint: MultiPoint<f64> = MultiPoint::empty(Dimension::XY);
-
         assert_eq!("MULTIPOINT EMPTY", format!("{}", multipoint));
+
+        let multipoint: MultiPoint<f64> = MultiPoint::empty(Dimension::XYZ);
+        assert_eq!("MULTIPOINT Z EMPTY", format!("{}", multipoint));
+
+        let multipoint: MultiPoint<f64> = MultiPoint::empty(Dimension::XYM);
+        assert_eq!("MULTIPOINT M EMPTY", format!("{}", multipoint));
+
+        let multipoint: MultiPoint<f64> = MultiPoint::empty(Dimension::XYZM);
+        assert_eq!("MULTIPOINT ZM EMPTY", format!("{}", multipoint));
     }
 
     #[test]

--- a/src/types/multipoint.rs
+++ b/src/types/multipoint.rs
@@ -54,9 +54,14 @@ impl<T: WktNum> MultiPoint<T> {
         Self::new(points, dim)
     }
 
-    /// Return the dimension of this geometry.
+    /// Return the [Dimension] of this geometry.
     pub fn dimension(&self) -> Dimension {
         self.dim
+    }
+
+    /// Access the inner points.
+    pub fn points(&self) -> &[Point<T>] {
+        &self.points
     }
 
     /// Consume self and return the inner parts.

--- a/src/types/multipoint.rs
+++ b/src/types/multipoint.rs
@@ -29,6 +29,7 @@ pub struct MultiPoint<T: WktNum> {
 }
 
 impl<T: WktNum> MultiPoint<T> {
+    /// Create a new MultiPoint from a sequence of [Point] and known [Dimension].
     pub fn new(points: Vec<Point<T>>, dim: Dimension) -> Self {
         MultiPoint { dim, points }
     }

--- a/src/types/multipoint.rs
+++ b/src/types/multipoint.rs
@@ -83,6 +83,10 @@ where
         );
         result.map(|points| MultiPoint { points, dim })
     }
+
+    fn new_empty(dim: Dimension) -> Self {
+        Self::empty(dim)
+    }
 }
 
 impl<T: WktNum> MultiPointTrait for MultiPoint<T> {
@@ -213,6 +217,45 @@ mod tests {
             _ => unreachable!(),
         };
         assert_eq!(0, points.len());
+    }
+
+    #[test]
+    fn parse_empty_multipoint() {
+        let wkt: Wkt<f64> = Wkt::from_str("MULTIPOINT EMPTY").ok().unwrap();
+        match wkt {
+            Wkt::MultiPoint(MultiPoint { points, dim }) => {
+                assert!(points.is_empty());
+                assert_eq!(dim, Dimension::XY);
+            }
+            _ => unreachable!(),
+        };
+
+        let wkt: Wkt<f64> = Wkt::from_str("MULTIPOINT Z EMPTY").ok().unwrap();
+        match wkt {
+            Wkt::MultiPoint(MultiPoint { points, dim }) => {
+                assert!(points.is_empty());
+                assert_eq!(dim, Dimension::XYZ);
+            }
+            _ => unreachable!(),
+        };
+
+        let wkt: Wkt<f64> = Wkt::from_str("MULTIPOINT M EMPTY").ok().unwrap();
+        match wkt {
+            Wkt::MultiPoint(MultiPoint { points, dim }) => {
+                assert!(points.is_empty());
+                assert_eq!(dim, Dimension::XYM);
+            }
+            _ => unreachable!(),
+        };
+
+        let wkt: Wkt<f64> = Wkt::from_str("MULTIPOINT ZM EMPTY").ok().unwrap();
+        match wkt {
+            Wkt::MultiPoint(MultiPoint { points, dim }) => {
+                assert!(points.is_empty());
+                assert_eq!(dim, Dimension::XYZM);
+            }
+            _ => unreachable!(),
+        };
     }
 
     #[test]

--- a/src/types/multipoint.rs
+++ b/src/types/multipoint.rs
@@ -14,6 +14,7 @@
 
 use geo_traits::MultiPointTrait;
 
+use crate::error::Error;
 use crate::to_wkt::write_multi_point;
 use crate::tokenizer::PeekableTokens;
 use crate::types::point::Point;
@@ -45,13 +46,20 @@ impl<T: WktNum> MultiPoint<T> {
     /// This will infer the dimension from the first point, and will not validate that all
     /// points have the same dimension.
     ///
-    /// ## Panics
+    /// ## Errors
     ///
     /// If the input iterator is empty.
-    pub fn from_points(points: impl IntoIterator<Item = Point<T>>) -> Self {
+    ///
+    /// To handle empty input iterators, consider calling `unwrap_or` on the result and defaulting
+    /// to an [empty][Self::empty] geometry with specified dimension.
+    pub fn from_points(points: impl IntoIterator<Item = Point<T>>) -> Result<Self, Error> {
         let points = points.into_iter().collect::<Vec<_>>();
-        let dim = points[0].dimension();
-        Self::new(points, dim)
+        if points.is_empty() {
+            Err(Error::UnknownDimension)
+        } else {
+            let dim = points[0].dimension();
+            Ok(Self::new(points, dim))
+        }
     }
 
     /// Return the [Dimension] of this geometry.
@@ -301,7 +309,8 @@ mod tests {
                 z: None,
                 m: None,
             }),
-        ]);
+        ])
+        .unwrap();
 
         assert_eq!(
             "MULTIPOINT((10.1 20.2),(30.3 40.4))",

--- a/src/types/multipoint.rs
+++ b/src/types/multipoint.rs
@@ -23,7 +23,16 @@ use std::fmt;
 use std::str::FromStr;
 
 #[derive(Clone, Debug, Default, PartialEq)]
-pub struct MultiPoint<T: WktNum>(pub Vec<Point<T>>);
+pub struct MultiPoint<T: WktNum> {
+    dim: Dimension,
+    points: Vec<Point<T>>,
+}
+
+impl<T: WktNum> MultiPoint<T> {
+    pub fn new(points: Vec<Point<T>>, dim: Dimension) -> Self {
+        MultiPoint { dim, points }
+    }
+}
 
 impl<T> From<MultiPoint<T>> for Wkt<T>
 where
@@ -65,20 +74,15 @@ impl<T: WktNum> MultiPointTrait for MultiPoint<T> {
         Self: 'a;
 
     fn dim(&self) -> geo_traits::Dimensions {
-        // TODO: infer dimension from empty WKT
-        if self.0.is_empty() {
-            geo_traits::Dimensions::Xy
-        } else {
-            self.0[0].dim()
-        }
+        self.dim.into()
     }
 
     fn num_points(&self) -> usize {
-        self.0.len()
+        self.points.len()
     }
 
     unsafe fn point_unchecked(&self, i: usize) -> Self::PointType<'_> {
-        self.0.get_unchecked(i)
+        self.points.get_unchecked(i)
     }
 }
 
@@ -90,20 +94,15 @@ impl<T: WktNum> MultiPointTrait for &MultiPoint<T> {
         Self: 'a;
 
     fn dim(&self) -> geo_traits::Dimensions {
-        // TODO: infer dimension from empty WKT
-        if self.0.is_empty() {
-            geo_traits::Dimensions::Xy
-        } else {
-            self.0[0].dim()
-        }
+        self.dim.into()
     }
 
     fn num_points(&self) -> usize {
-        self.0.len()
+        self.points.len()
     }
 
     unsafe fn point_unchecked(&self, i: usize) -> Self::PointType<'_> {
-        self.0.get_unchecked(i)
+        self.points.get_unchecked(i)
     }
 }
 

--- a/src/types/multipoint.rs
+++ b/src/types/multipoint.rs
@@ -22,10 +22,11 @@ use crate::{FromTokens, Wkt, WktNum};
 use std::fmt;
 use std::str::FromStr;
 
+/// A parsed MultiPoint.
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct MultiPoint<T: WktNum = f64> {
-    pub(crate) dim: Dimension,
     pub(crate) points: Vec<Point<T>>,
+    pub(crate) dim: Dimension,
 }
 
 impl<T: WktNum> MultiPoint<T> {
@@ -49,8 +50,18 @@ impl<T: WktNum> MultiPoint<T> {
     /// If the input iterator is empty.
     pub fn from_points(points: impl IntoIterator<Item = Point<T>>) -> Self {
         let points = points.into_iter().collect::<Vec<_>>();
-        let dim = points[0].dim;
+        let dim = points[0].dimension();
         Self::new(points, dim)
+    }
+
+    /// Return the dimension of this geometry.
+    pub fn dimension(&self) -> Dimension {
+        self.dim
+    }
+
+    /// Consume self and return the inner parts.
+    pub fn into_inner(self) -> (Vec<Point<T>>, Dimension) {
+        (self.points, self.dim)
     }
 }
 

--- a/src/types/multipoint.rs
+++ b/src/types/multipoint.rs
@@ -81,7 +81,7 @@ where
             tokens,
             dim,
         );
-        result.map(MultiPoint)
+        result.map(|points| MultiPoint { points, dim })
     }
 }
 

--- a/src/types/multipolygon.rs
+++ b/src/types/multipolygon.rs
@@ -54,9 +54,14 @@ impl<T: WktNum> MultiPolygon<T> {
         Self::new(polygons, dim)
     }
 
-    /// Return the dimension of this geometry.
+    /// Return the [Dimension] of this geometry.
     pub fn dimension(&self) -> Dimension {
         self.dim
+    }
+
+    /// Access the inner polygons.
+    pub fn polygons(&self) -> &[Polygon<T>] {
+        &self.polygons
     }
 
     /// Consume self and return the inner parts.

--- a/src/types/multipolygon.rs
+++ b/src/types/multipolygon.rs
@@ -83,6 +83,10 @@ where
         );
         result.map(|polygons| MultiPolygon { polygons, dim })
     }
+
+    fn new_empty(dim: Dimension) -> Self {
+        Self::empty(dim)
+    }
 }
 
 impl<T: WktNum> MultiPolygonTrait for MultiPolygon<T> {
@@ -142,6 +146,45 @@ mod tests {
             _ => unreachable!(),
         };
         assert_eq!(2, polygons.len());
+    }
+
+    #[test]
+    fn parse_empty_multipolygon() {
+        let wkt: Wkt<f64> = Wkt::from_str("MULTIPOLYGON EMPTY").ok().unwrap();
+        match wkt {
+            Wkt::MultiPolygon(MultiPolygon { polygons, dim }) => {
+                assert!(polygons.is_empty());
+                assert_eq!(dim, Dimension::XY);
+            }
+            _ => unreachable!(),
+        };
+
+        let wkt: Wkt<f64> = Wkt::from_str("MULTIPOLYGON Z EMPTY").ok().unwrap();
+        match wkt {
+            Wkt::MultiPolygon(MultiPolygon { polygons, dim }) => {
+                assert!(polygons.is_empty());
+                assert_eq!(dim, Dimension::XYZ);
+            }
+            _ => unreachable!(),
+        };
+
+        let wkt: Wkt<f64> = Wkt::from_str("MULTIPOLYGON M EMPTY").ok().unwrap();
+        match wkt {
+            Wkt::MultiPolygon(MultiPolygon { polygons, dim }) => {
+                assert!(polygons.is_empty());
+                assert_eq!(dim, Dimension::XYM);
+            }
+            _ => unreachable!(),
+        };
+
+        let wkt: Wkt<f64> = Wkt::from_str("MULTIPOLYGON ZM EMPTY").ok().unwrap();
+        match wkt {
+            Wkt::MultiPolygon(MultiPolygon { polygons, dim }) => {
+                assert!(polygons.is_empty());
+                assert_eq!(dim, Dimension::XYZM);
+            }
+            _ => unreachable!(),
+        };
     }
 
     #[test]

--- a/src/types/multipolygon.rs
+++ b/src/types/multipolygon.rs
@@ -29,6 +29,7 @@ pub struct MultiPolygon<T: WktNum> {
 }
 
 impl<T: WktNum> MultiPolygon<T> {
+    /// Create a new MultiPolygon from a sequence of [Polygon] and known [Dimension].
     pub fn new(polygons: Vec<Polygon<T>>, dim: Dimension) -> Self {
         MultiPolygon { dim, polygons }
     }

--- a/src/types/multipolygon.rs
+++ b/src/types/multipolygon.rs
@@ -147,8 +147,16 @@ mod tests {
     #[test]
     fn write_empty_multipolygon() {
         let multipolygon: MultiPolygon<f64> = MultiPolygon::empty(Dimension::XY);
-
         assert_eq!("MULTIPOLYGON EMPTY", format!("{}", multipolygon));
+
+        let multipolygon: MultiPolygon<f64> = MultiPolygon::empty(Dimension::XYZ);
+        assert_eq!("MULTIPOLYGON Z EMPTY", format!("{}", multipolygon));
+
+        let multipolygon: MultiPolygon<f64> = MultiPolygon::empty(Dimension::XYM);
+        assert_eq!("MULTIPOLYGON M EMPTY", format!("{}", multipolygon));
+
+        let multipolygon: MultiPolygon<f64> = MultiPolygon::empty(Dimension::XYZM);
+        assert_eq!("MULTIPOLYGON ZM EMPTY", format!("{}", multipolygon));
     }
 
     #[test]

--- a/src/types/multipolygon.rs
+++ b/src/types/multipolygon.rs
@@ -22,10 +22,11 @@ use crate::{FromTokens, Wkt, WktNum};
 use std::fmt;
 use std::str::FromStr;
 
+/// A parsed MultiPolygon.
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct MultiPolygon<T: WktNum = f64> {
-    pub(crate) dim: Dimension,
     pub(crate) polygons: Vec<Polygon<T>>,
+    pub(crate) dim: Dimension,
 }
 
 impl<T: WktNum> MultiPolygon<T> {
@@ -49,8 +50,18 @@ impl<T: WktNum> MultiPolygon<T> {
     /// If the input iterator is empty.
     pub fn from_polygons(polygons: impl IntoIterator<Item = Polygon<T>>) -> Self {
         let polygons = polygons.into_iter().collect::<Vec<_>>();
-        let dim = polygons[0].dim;
+        let dim = polygons[0].dimension();
         Self::new(polygons, dim)
+    }
+
+    /// Return the dimension of this geometry.
+    pub fn dimension(&self) -> Dimension {
+        self.dim
+    }
+
+    /// Consume self and return the inner parts.
+    pub fn into_inner(self) -> (Vec<Polygon<T>>, Dimension) {
+        (self.polygons, self.dim)
     }
 }
 

--- a/src/types/multipolygon.rs
+++ b/src/types/multipolygon.rs
@@ -81,7 +81,7 @@ where
             tokens,
             dim,
         );
-        result.map(MultiPolygon)
+        result.map(|polygons| MultiPolygon { polygons, dim })
     }
 }
 

--- a/src/types/multipolygon.rs
+++ b/src/types/multipolygon.rs
@@ -23,7 +23,16 @@ use std::fmt;
 use std::str::FromStr;
 
 #[derive(Clone, Debug, Default, PartialEq)]
-pub struct MultiPolygon<T: WktNum>(pub Vec<Polygon<T>>);
+pub struct MultiPolygon<T: WktNum> {
+    dim: Dimension,
+    polygons: Vec<Polygon<T>>,
+}
+
+impl<T: WktNum> MultiPolygon<T> {
+    pub fn new(polygons: Vec<Polygon<T>>, dim: Dimension) -> Self {
+        MultiPolygon { dim, polygons }
+    }
+}
 
 impl<T> From<MultiPolygon<T>> for Wkt<T>
 where
@@ -65,20 +74,15 @@ impl<T: WktNum> MultiPolygonTrait for MultiPolygon<T> {
         Self: 'a;
 
     fn dim(&self) -> geo_traits::Dimensions {
-        // TODO: infer dimension from empty WKT
-        if self.0.is_empty() {
-            geo_traits::Dimensions::Xy
-        } else {
-            self.0[0].dim()
-        }
+        self.dim.into()
     }
 
     fn num_polygons(&self) -> usize {
-        self.0.len()
+        self.polygons.len()
     }
 
     unsafe fn polygon_unchecked(&self, i: usize) -> Self::PolygonType<'_> {
-        self.0.get_unchecked(i)
+        self.polygons.get_unchecked(i)
     }
 }
 
@@ -90,20 +94,15 @@ impl<T: WktNum> MultiPolygonTrait for &MultiPolygon<T> {
         Self: 'a;
 
     fn dim(&self) -> geo_traits::Dimensions {
-        // TODO: infer dimension from empty WKT
-        if self.0.is_empty() {
-            geo_traits::Dimensions::Xy
-        } else {
-            self.0[0].dim()
-        }
+        self.dim.into()
     }
 
     fn num_polygons(&self) -> usize {
-        self.0.len()
+        self.polygons.len()
     }
 
     unsafe fn polygon_unchecked(&self, i: usize) -> Self::PolygonType<'_> {
-        self.0.get_unchecked(i)
+        self.polygons.get_unchecked(i)
     }
 }
 

--- a/src/types/point.rs
+++ b/src/types/point.rs
@@ -29,6 +29,7 @@ pub struct Point<T: WktNum> {
 }
 
 impl<T: WktNum> Point<T> {
+    /// Create a new Point from a coordinate and known [Dimension].
     pub fn new(coord: Option<Coord<T>>, dim: Dimension) -> Self {
         Self { dim, coord }
     }

--- a/src/types/point.rs
+++ b/src/types/point.rs
@@ -125,40 +125,43 @@ mod tests {
     #[test]
     fn basic_point() {
         let wkt: Wkt<f64> = Wkt::from_str("POINT (10 -20)").ok().unwrap();
-        let coord = match wkt {
-            Wkt::Point(Point { coord, dim: _ }) => coord.unwrap(),
+        let (coord, dim) = match wkt {
+            Wkt::Point(Point { coord, dim }) => (coord.unwrap(), dim),
             _ => unreachable!(),
         };
         assert_eq!(10.0, coord.x);
         assert_eq!(-20.0, coord.y);
         assert_eq!(None, coord.z);
         assert_eq!(None, coord.m);
+        assert_eq!(dim, Dimension::XY);
     }
 
     #[test]
     fn basic_point_z() {
         let wkt = Wkt::from_str("POINT Z(-117 33 10)").ok().unwrap();
-        let coord = match wkt {
-            Wkt::Point(Point { coord, dim: _ }) => coord.unwrap(),
+        let (coord, dim) = match wkt {
+            Wkt::Point(Point { coord, dim }) => (coord.unwrap(), dim),
             _ => unreachable!(),
         };
         assert_eq!(-117.0, coord.x);
         assert_eq!(33.0, coord.y);
         assert_eq!(Some(10.0), coord.z);
         assert_eq!(None, coord.m);
+        assert_eq!(dim, Dimension::XYZ);
     }
 
     #[test]
     fn basic_point_z_one_word() {
         let wkt = Wkt::from_str("POINTZ(-117 33 10)").ok().unwrap();
-        let coord = match wkt {
-            Wkt::Point(Point { coord, dim: _ }) => coord.unwrap(),
+        let (coord, dim) = match wkt {
+            Wkt::Point(Point { coord, dim }) => (coord.unwrap(), dim),
             _ => unreachable!(),
         };
         assert_eq!(-117.0, coord.x);
         assert_eq!(33.0, coord.y);
         assert_eq!(Some(10.0), coord.z);
         assert_eq!(None, coord.m);
+        assert_eq!(dim, Dimension::XYZ);
     }
 
     #[test]
@@ -166,14 +169,15 @@ mod tests {
         let wkt: Wkt<f64> = Wkt::from_str(" \n\t\rPOINT \n\t\r( \n\r\t10 \n\t\r-20 \n\t\r) \n\t\r")
             .ok()
             .unwrap();
-        let coord = match wkt {
-            Wkt::Point(Point { coord, dim: _ }) => coord.unwrap(),
+        let (coord, dim) = match wkt {
+            Wkt::Point(Point { coord, dim }) => (coord.unwrap(), dim),
             _ => unreachable!(),
         };
         assert_eq!(10.0, coord.x);
         assert_eq!(-20.0, coord.y);
         assert_eq!(None, coord.z);
         assert_eq!(None, coord.m);
+        assert_eq!(dim, Dimension::XY);
     }
 
     #[test]

--- a/src/types/point.rs
+++ b/src/types/point.rs
@@ -73,7 +73,10 @@ where
 {
     fn from_tokens(tokens: &mut PeekableTokens<T>, dim: Dimension) -> Result<Self, &'static str> {
         let result = <Coord<T> as FromTokens<T>>::from_tokens(tokens, dim);
-        result.map(|coord| Point(Some(coord)))
+        result.map(|coord| Point {
+            coord: Some(coord),
+            dim,
+        })
     }
 }
 

--- a/src/types/point.rs
+++ b/src/types/point.rs
@@ -36,7 +36,7 @@ impl<T: WktNum> Point<T> {
     /// Create a new point from a valid [Coord].
     ///
     /// This infers the dimension from the coordinate.
-    pub(crate) fn from_coord(coord: Coord<T>) -> Self {
+    pub fn from_coord(coord: Coord<T>) -> Self {
         Self {
             dim: coord.dimension(),
             coord: Some(coord),

--- a/src/types/point.rs
+++ b/src/types/point.rs
@@ -50,9 +50,14 @@ impl<T: WktNum> Point<T> {
         Self::new(None, dim)
     }
 
-    /// Return the dimension of this geometry.
+    /// Return the [Dimension] of this geometry.
     pub fn dimension(&self) -> Dimension {
         self.dim
+    }
+
+    /// Access the coordinate of this point.
+    pub fn coord(&self) -> Option<&Coord<T>> {
+        self.coord.as_ref()
     }
 
     /// Consume self and return the inner parts.

--- a/src/types/point.rs
+++ b/src/types/point.rs
@@ -173,6 +173,45 @@ mod tests {
     }
 
     #[test]
+    fn parse_empty_point() {
+        let wkt: Wkt<f64> = Wkt::from_str("POINT EMPTY").ok().unwrap();
+        match wkt {
+            Wkt::Point(Point { coord, dim }) => {
+                assert!(coord.is_none());
+                assert_eq!(dim, Dimension::XY);
+            }
+            _ => unreachable!(),
+        };
+
+        let wkt: Wkt<f64> = Wkt::from_str("POINT Z EMPTY").ok().unwrap();
+        match wkt {
+            Wkt::Point(Point { coord, dim }) => {
+                assert!(coord.is_none());
+                assert_eq!(dim, Dimension::XYZ);
+            }
+            _ => unreachable!(),
+        };
+
+        let wkt: Wkt<f64> = Wkt::from_str("POINT M EMPTY").ok().unwrap();
+        match wkt {
+            Wkt::Point(Point { coord, dim }) => {
+                assert!(coord.is_none());
+                assert_eq!(dim, Dimension::XYM);
+            }
+            _ => unreachable!(),
+        };
+
+        let wkt: Wkt<f64> = Wkt::from_str("POINT ZM EMPTY").ok().unwrap();
+        match wkt {
+            Wkt::Point(Point { coord, dim }) => {
+                assert!(coord.is_none());
+                assert_eq!(dim, Dimension::XYZM);
+            }
+            _ => unreachable!(),
+        };
+    }
+
+    #[test]
     fn invalid_points() {
         <Wkt<f64>>::from_str("POINT ()").err().unwrap();
         <Wkt<f64>>::from_str("POINT (10)").err().unwrap();

--- a/src/types/point.rs
+++ b/src/types/point.rs
@@ -22,16 +22,17 @@ use crate::{FromTokens, Wkt, WktNum};
 use std::fmt;
 use std::str::FromStr;
 
+/// A parsed Point.
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct Point<T: WktNum = f64> {
-    pub(crate) dim: Dimension,
     pub(crate) coord: Option<Coord<T>>,
+    pub(crate) dim: Dimension,
 }
 
 impl<T: WktNum> Point<T> {
     /// Create a new Point from a coordinate and known [Dimension].
     pub fn new(coord: Option<Coord<T>>, dim: Dimension) -> Self {
-        Self { dim, coord }
+        Self { coord, dim }
     }
 
     /// Create a new point from a valid [Coord].
@@ -47,6 +48,16 @@ impl<T: WktNum> Point<T> {
     /// Create a new empty point.
     pub fn empty(dim: Dimension) -> Self {
         Self::new(None, dim)
+    }
+
+    /// Return the dimension of this geometry.
+    pub fn dimension(&self) -> Dimension {
+        self.dim
+    }
+
+    /// Consume self and return the inner parts.
+    pub fn into_inner(self) -> (Option<Coord<T>>, Dimension) {
+        (self.coord, self.dim)
     }
 }
 

--- a/src/types/point.rs
+++ b/src/types/point.rs
@@ -23,7 +23,16 @@ use std::fmt;
 use std::str::FromStr;
 
 #[derive(Clone, Debug, Default, PartialEq)]
-pub struct Point<T: WktNum>(pub Option<Coord<T>>);
+pub struct Point<T: WktNum> {
+    dim: Dimension,
+    coord: Option<Coord<T>>,
+}
+
+impl<T: WktNum> Point<T> {
+    pub fn new(coord: Option<Coord<T>>, dim: Dimension) -> Self {
+        Point { dim, coord }
+    }
+}
 
 impl<T> From<Point<T>> for Wkt<T>
 where
@@ -61,16 +70,11 @@ impl<T: WktNum> PointTrait for Point<T> {
         Self: 'a;
 
     fn dim(&self) -> geo_traits::Dimensions {
-        if let Some(coord) = &self.0 {
-            coord.dim()
-        } else {
-            // TODO: infer dimension from empty WKT
-            geo_traits::Dimensions::Xy
-        }
+        self.dim.into()
     }
 
     fn coord(&self) -> Option<Self::CoordType<'_>> {
-        self.0.as_ref()
+        self.coord.as_ref()
     }
 }
 
@@ -82,16 +86,11 @@ impl<T: WktNum> PointTrait for &Point<T> {
         Self: 'a;
 
     fn dim(&self) -> geo_traits::Dimensions {
-        if let Some(coord) = &self.0 {
-            coord.dim()
-        } else {
-            // TODO: infer dimension from empty WKT
-            geo_traits::Dimensions::Xy
-        }
+        self.dim.into()
     }
 
     fn coord(&self) -> Option<Self::CoordType<'_>> {
-        self.0.as_ref()
+        self.coord.as_ref()
     }
 }
 #[cfg(test)]

--- a/src/types/point.rs
+++ b/src/types/point.rs
@@ -78,6 +78,10 @@ where
             dim,
         })
     }
+
+    fn new_empty(dim: Dimension) -> Self {
+        Self::empty(dim)
+    }
 }
 
 impl<T: WktNum> PointTrait for Point<T> {

--- a/src/types/point.rs
+++ b/src/types/point.rs
@@ -182,8 +182,16 @@ mod tests {
     #[test]
     fn write_empty_point() {
         let point: Point<f64> = Point::empty(Dimension::XY);
-
         assert_eq!("POINT EMPTY", format!("{}", point));
+
+        let point: Point<f64> = Point::empty(Dimension::XYZ);
+        assert_eq!("POINT Z EMPTY", format!("{}", point));
+
+        let point: Point<f64> = Point::empty(Dimension::XYM);
+        assert_eq!("POINT M EMPTY", format!("{}", point));
+
+        let point: Point<f64> = Point::empty(Dimension::XYZM);
+        assert_eq!("POINT ZM EMPTY", format!("{}", point));
     }
 
     #[test]

--- a/src/types/polygon.rs
+++ b/src/types/polygon.rs
@@ -155,8 +155,16 @@ mod tests {
     #[test]
     fn write_empty_polygon() {
         let polygon: Polygon<f64> = Polygon::empty(Dimension::XY);
-
         assert_eq!("POLYGON EMPTY", format!("{}", polygon));
+
+        let polygon: Polygon<f64> = Polygon::empty(Dimension::XYZ);
+        assert_eq!("POLYGON Z EMPTY", format!("{}", polygon));
+
+        let polygon: Polygon<f64> = Polygon::empty(Dimension::XYM);
+        assert_eq!("POLYGON M EMPTY", format!("{}", polygon));
+
+        let polygon: Polygon<f64> = Polygon::empty(Dimension::XYZM);
+        assert_eq!("POLYGON ZM EMPTY", format!("{}", polygon));
     }
 
     #[test]

--- a/src/types/polygon.rs
+++ b/src/types/polygon.rs
@@ -150,7 +150,10 @@ mod tests {
             .ok()
             .unwrap();
         let rings = match wkt {
-            Wkt::Polygon(Polygon { rings, dim: _ }) => rings,
+            Wkt::Polygon(Polygon { rings, dim }) => {
+                assert_eq!(dim, Dimension::XY);
+                rings
+            }
             _ => unreachable!(),
         };
         assert_eq!(2, rings.len());

--- a/src/types/polygon.rs
+++ b/src/types/polygon.rs
@@ -14,6 +14,7 @@
 
 use geo_traits::PolygonTrait;
 
+use crate::error::Error;
 use crate::to_wkt::write_polygon;
 use crate::tokenizer::PeekableTokens;
 use crate::types::linestring::LineString;
@@ -45,13 +46,20 @@ impl<T: WktNum> Polygon<T> {
     /// This will infer the dimension from the first line string, and will not validate that all
     /// line strings have the same dimension.
     ///
-    /// ## Panics
+    /// ## Errors
     ///
     /// If the input iterator is empty.
-    pub fn from_rings(rings: impl IntoIterator<Item = LineString<T>>) -> Self {
+    ///
+    /// To handle empty input iterators, consider calling `unwrap_or` on the result and defaulting
+    /// to an [empty][Self::empty] geometry with specified dimension.
+    pub fn from_rings(rings: impl IntoIterator<Item = LineString<T>>) -> Result<Self, Error> {
         let rings = rings.into_iter().collect::<Vec<_>>();
-        let dim = rings[0].dimension();
-        Self::new(rings, dim)
+        if rings.is_empty() {
+            Err(Error::UnknownDimension)
+        } else {
+            let dim = rings[0].dimension();
+            Ok(Self::new(rings, dim))
+        }
     }
 
     /// Return the [Dimension] of this geometry.
@@ -260,7 +268,8 @@ mod tests {
                     z: None,
                     m: None,
                 },
-            ]),
+            ])
+            .unwrap(),
             LineString::from_coords([
                 Coord {
                     x: 5.,
@@ -286,8 +295,10 @@ mod tests {
                     z: None,
                     m: None,
                 },
-            ]),
-        ]);
+            ])
+            .unwrap(),
+        ])
+        .unwrap();
 
         assert_eq!(
             "POLYGON((0 0,20 40,40 0,0 0),(5 5,20 30,30 5,5 5))",

--- a/src/types/polygon.rs
+++ b/src/types/polygon.rs
@@ -81,7 +81,7 @@ where
             tokens,
             dim,
         );
-        result.map(Polygon)
+        result.map(|rings| Polygon { rings, dim })
     }
 }
 

--- a/src/types/polygon.rs
+++ b/src/types/polygon.rs
@@ -54,9 +54,16 @@ impl<T: WktNum> Polygon<T> {
         Self::new(rings, dim)
     }
 
-    /// Return the dimension of this geometry.
+    /// Return the [Dimension] of this geometry.
     pub fn dimension(&self) -> Dimension {
         self.dim
+    }
+
+    /// Access the inner rings.
+    ///
+    /// The first ring is defined to be the exterior ring, and the rest are interior rings.
+    pub fn rings(&self) -> &[LineString<T>] {
+        &self.rings
     }
 
     /// Consume self and return the inner parts.

--- a/src/types/polygon.rs
+++ b/src/types/polygon.rs
@@ -22,10 +22,11 @@ use crate::{FromTokens, Wkt, WktNum};
 use std::fmt;
 use std::str::FromStr;
 
+/// A parsed Polygon.
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct Polygon<T: WktNum = f64> {
-    pub(crate) dim: Dimension,
     pub(crate) rings: Vec<LineString<T>>,
+    pub(crate) dim: Dimension,
 }
 
 impl<T: WktNum> Polygon<T> {
@@ -49,8 +50,18 @@ impl<T: WktNum> Polygon<T> {
     /// If the input iterator is empty.
     pub fn from_rings(rings: impl IntoIterator<Item = LineString<T>>) -> Self {
         let rings = rings.into_iter().collect::<Vec<_>>();
-        let dim = rings[0].dim;
+        let dim = rings[0].dimension();
         Self::new(rings, dim)
+    }
+
+    /// Return the dimension of this geometry.
+    pub fn dimension(&self) -> Dimension {
+        self.dim
+    }
+
+    /// Consume self and return the inner parts.
+    pub fn into_inner(self) -> (Vec<LineString<T>>, Dimension) {
+        (self.rings, self.dim)
     }
 }
 

--- a/src/types/polygon.rs
+++ b/src/types/polygon.rs
@@ -29,6 +29,7 @@ pub struct Polygon<T: WktNum> {
 }
 
 impl<T: WktNum> Polygon<T> {
+    /// Create a new Polygon from a sequence of [LineString] and known [Dimension].
     pub fn new(rings: Vec<LineString<T>>, dim: Dimension) -> Self {
         Polygon { dim, rings }
     }

--- a/src/types/polygon.rs
+++ b/src/types/polygon.rs
@@ -83,6 +83,10 @@ where
         );
         result.map(|rings| Polygon { rings, dim })
     }
+
+    fn new_empty(dim: Dimension) -> Self {
+        Self::empty(dim)
+    }
 }
 
 impl<T: WktNum> PolygonTrait for Polygon<T> {
@@ -150,6 +154,45 @@ mod tests {
             _ => unreachable!(),
         };
         assert_eq!(2, rings.len());
+    }
+
+    #[test]
+    fn parse_empty_polygon() {
+        let wkt: Wkt<f64> = Wkt::from_str("POLYGON EMPTY").ok().unwrap();
+        match wkt {
+            Wkt::Polygon(Polygon { rings, dim }) => {
+                assert!(rings.is_empty());
+                assert_eq!(dim, Dimension::XY);
+            }
+            _ => unreachable!(),
+        };
+
+        let wkt: Wkt<f64> = Wkt::from_str("POLYGON Z EMPTY").ok().unwrap();
+        match wkt {
+            Wkt::Polygon(Polygon { rings, dim }) => {
+                assert!(rings.is_empty());
+                assert_eq!(dim, Dimension::XYZ);
+            }
+            _ => unreachable!(),
+        };
+
+        let wkt: Wkt<f64> = Wkt::from_str("POLYGON M EMPTY").ok().unwrap();
+        match wkt {
+            Wkt::Polygon(Polygon { rings, dim }) => {
+                assert!(rings.is_empty());
+                assert_eq!(dim, Dimension::XYM);
+            }
+            _ => unreachable!(),
+        };
+
+        let wkt: Wkt<f64> = Wkt::from_str("POLYGON ZM EMPTY").ok().unwrap();
+        match wkt {
+            Wkt::Polygon(Polygon { rings, dim }) => {
+                assert!(rings.is_empty());
+                assert_eq!(dim, Dimension::XYZM);
+            }
+            _ => unreachable!(),
+        };
     }
 
     #[test]


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
- [x] I ran cargo fmt
---

Closes https://github.com/georust/wkt/issues/125

### Change list

- Add `dim: Dimension` field to all WKT geometry types.
- Move the `.0` field to a named field in the struct, e.g. `coord` for `wkt::types::Point`. This is **breaking** because the `.0` field was public before.
- Add new constructors for each wkt type
    - `new`: construct from a known inner and a dimension
    - `from_*`, e.g. `Point::from_coord`, `LineString::from_coords`, `Polygon::from_rings`, which take the dimension from the first input item of the sequence and panic on empty sequences.
    - `empty`: construct a new empty geometry from just a dimension
- Update tests. For anything that's now passed to `from_*`, I mostly changed all the `vec![]` to arrays for slightly simpler code.
- Fix `infer_type` to never return `None` for the dimension. Dimension can always be accurately inferred from the presence of `Z`, `M`, or `ZM` in a `GEOM EMPTY` string


Questions:

- Do we need to expose a public accessor for the internal of a wkt type, which was previously accessible via `.0`?
- 