### PR TITLE
Default to using `f64` for `WktNum` in WKT types

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,10 @@
 
 * Your change here.
 
+## 0.13.0 - unreleased
+
+* Default to using `f64` for `WktNum` in WKT types
+
 ## 0.12.0 - 2024-11-27
 
 * Writing WKT is now up to 50% faster by avoiding extra allocations and writing directly to an underlying buffer.

--- a/src/geo_types_from_wkt.rs
+++ b/src/geo_types_from_wkt.rs
@@ -434,7 +434,7 @@ mod tests {
 
     #[test]
     fn convert_linestring() {
-        let w_linestring: Wkt<f64> = LineString(vec![
+        let w_linestring: Wkt = LineString(vec![
             Coord {
                 x: 10.,
                 y: 20.,
@@ -458,7 +458,7 @@ mod tests {
 
     #[test]
     fn convert_empty_polygon() {
-        let w_polygon: Wkt<f64> = Polygon(vec![]).into();
+        let w_polygon: Wkt = Polygon(vec![]).into();
         let g_polygon: geo_types::Polygon<f64> =
             geo_types::Polygon::new(geo_types::LineString(vec![]), vec![]);
         assert_eq!(
@@ -469,7 +469,7 @@ mod tests {
 
     #[test]
     fn convert_polygon() {
-        let w_polygon: Wkt<f64> = Polygon(vec![
+        let w_polygon: Wkt = Polygon(vec![
             LineString(vec![
                 Coord {
                     x: 0.,
@@ -536,7 +536,7 @@ mod tests {
 
     #[test]
     fn convert_empty_multilinestring() {
-        let w_multilinestring: Wkt<f64> = MultiLineString(vec![]).into();
+        let w_multilinestring: Wkt = MultiLineString(vec![]).into();
         let g_multilinestring: geo_types::MultiLineString<f64> = geo_types::MultiLineString(vec![]);
         assert_eq!(
             geo_types::Geometry::MultiLineString(g_multilinestring),
@@ -546,7 +546,7 @@ mod tests {
 
     #[test]
     fn convert_multilinestring() {
-        let w_multilinestring: Wkt<f64> = MultiLineString(vec![
+        let w_multilinestring: Wkt = MultiLineString(vec![
             LineString(vec![
                 Coord {
                     x: 10.,
@@ -589,7 +589,7 @@ mod tests {
 
     #[test]
     fn convert_empty_multipoint() {
-        let w_multipoint: Wkt<f64> = MultiPoint(vec![]).into();
+        let w_multipoint: Wkt = MultiPoint(vec![]).into();
         let g_multipoint: geo_types::MultiPoint<f64> = geo_types::MultiPoint(vec![]);
         assert_eq!(
             geo_types::Geometry::MultiPoint(g_multipoint),
@@ -599,7 +599,7 @@ mod tests {
 
     #[test]
     fn convert_multipoint() {
-        let w_multipoint: Wkt<f64> = MultiPoint(vec![
+        let w_multipoint: Wkt = MultiPoint(vec![
             Point(Some(Coord {
                 x: 10.,
                 y: 20.,
@@ -623,7 +623,7 @@ mod tests {
 
     #[test]
     fn convert_empty_multipolygon() {
-        let w_multipolygon: Wkt<f64> = MultiPolygon(vec![]).into();
+        let w_multipolygon: Wkt = MultiPolygon(vec![]).into();
         let g_multipolygon: geo_types::MultiPolygon<f64> = geo_types::MultiPolygon(vec![]);
         assert_eq!(
             geo_types::Geometry::MultiPolygon(g_multipolygon),
@@ -633,7 +633,7 @@ mod tests {
 
     #[test]
     fn convert_multipolygon() {
-        let w_multipolygon: Wkt<f64> = MultiPolygon(vec![
+        let w_multipolygon: Wkt = MultiPolygon(vec![
             Polygon(vec![
                 LineString(vec![
                     Coord {
@@ -735,7 +735,7 @@ mod tests {
 
     #[test]
     fn convert_empty_geometrycollection() {
-        let w_geometrycollection: Wkt<f64> = GeometryCollection(vec![]).into();
+        let w_geometrycollection: Wkt = GeometryCollection(vec![]).into();
         let g_geometrycollection: geo_types::GeometryCollection<f64> =
             geo_types::GeometryCollection(vec![]);
         assert_eq!(
@@ -902,7 +902,7 @@ mod tests {
         ])
         .into();
 
-        let w_geometrycollection: Wkt<f64> = GeometryCollection(vec![
+        let w_geometrycollection: Wkt = GeometryCollection(vec![
             w_point,
             w_multipoint,
             w_linestring,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -166,10 +166,7 @@ impl<T> WktFloat for T where T: WktNum + Float {}
 
 #[derive(Clone, Debug, PartialEq)]
 /// All supported WKT geometry [`types`]
-pub enum Wkt<T>
-where
-    T: WktNum,
-{
+pub enum Wkt<T: WktNum = f64> {
     Point(Point<T>),
     LineString(LineString<T>),
     Polygon(Polygon<T>),

--- a/src/types/coord.rs
+++ b/src/types/coord.rs
@@ -20,10 +20,7 @@ use crate::{FromTokens, WktNum};
 use std::str::FromStr;
 
 #[derive(Clone, Debug, Default, PartialEq)]
-pub struct Coord<T>
-where
-    T: WktNum,
-{
+pub struct Coord<T: WktNum = f64> {
     pub x: T,
     pub y: T,
     pub z: Option<T>,

--- a/src/types/geometrycollection.rs
+++ b/src/types/geometrycollection.rs
@@ -22,7 +22,7 @@ use std::fmt;
 use std::str::FromStr;
 
 #[derive(Clone, Debug, Default, PartialEq)]
-pub struct GeometryCollection<T: WktNum>(pub Vec<Wkt<T>>);
+pub struct GeometryCollection<T: WktNum = f64>(pub Vec<Wkt<T>>);
 
 impl<T> From<GeometryCollection<T>> for Wkt<T>
 where

--- a/src/types/linestring.rs
+++ b/src/types/linestring.rs
@@ -23,7 +23,7 @@ use std::fmt;
 use std::str::FromStr;
 
 #[derive(Clone, Debug, Default, PartialEq)]
-pub struct LineString<T: WktNum>(pub Vec<Coord<T>>);
+pub struct LineString<T: WktNum = f64>(pub Vec<Coord<T>>);
 
 impl<T> From<LineString<T>> for Wkt<T>
 where

--- a/src/types/multilinestring.rs
+++ b/src/types/multilinestring.rs
@@ -23,7 +23,7 @@ use std::fmt;
 use std::str::FromStr;
 
 #[derive(Clone, Debug, Default, PartialEq)]
-pub struct MultiLineString<T: WktNum>(pub Vec<LineString<T>>);
+pub struct MultiLineString<T: WktNum = f64>(pub Vec<LineString<T>>);
 
 impl<T> From<MultiLineString<T>> for Wkt<T>
 where

--- a/src/types/multipoint.rs
+++ b/src/types/multipoint.rs
@@ -23,7 +23,7 @@ use std::fmt;
 use std::str::FromStr;
 
 #[derive(Clone, Debug, Default, PartialEq)]
-pub struct MultiPoint<T: WktNum>(pub Vec<Point<T>>);
+pub struct MultiPoint<T: WktNum = f64>(pub Vec<Point<T>>);
 
 impl<T> From<MultiPoint<T>> for Wkt<T>
 where

--- a/src/types/multipolygon.rs
+++ b/src/types/multipolygon.rs
@@ -23,7 +23,7 @@ use std::fmt;
 use std::str::FromStr;
 
 #[derive(Clone, Debug, Default, PartialEq)]
-pub struct MultiPolygon<T: WktNum>(pub Vec<Polygon<T>>);
+pub struct MultiPolygon<T: WktNum = f64>(pub Vec<Polygon<T>>);
 
 impl<T> From<MultiPolygon<T>> for Wkt<T>
 where

--- a/src/types/point.rs
+++ b/src/types/point.rs
@@ -23,7 +23,7 @@ use std::fmt;
 use std::str::FromStr;
 
 #[derive(Clone, Debug, Default, PartialEq)]
-pub struct Point<T: WktNum>(pub Option<Coord<T>>);
+pub struct Point<T: WktNum = f64>(pub Option<Coord<T>>);
 
 impl<T> From<Point<T>> for Wkt<T>
 where

--- a/src/types/polygon.rs
+++ b/src/types/polygon.rs
@@ -23,7 +23,7 @@ use std::fmt;
 use std::str::FromStr;
 
 #[derive(Clone, Debug, Default, PartialEq)]
-pub struct Polygon<T: WktNum>(pub Vec<LineString<T>>);
+pub struct Polygon<T: WktNum = f64>(pub Vec<LineString<T>>);
 
 impl<T> From<Polygon<T>> for Wkt<T>
 where


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [ ] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
- [x] I ran cargo fmt
---

Similarly to `geo-types`, defaults to using `f64` as the `WktNum`. Not sure if this is controversial or not?