### PR TITLE
Remove allocation to `Wkt` when writing geo-types via `write_wkt`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 
 ## 0.13.0 - unreleased
 
+* Remove allocation to `Wkt` when writing geo-types via `write_wkt` (#140)
 * Default to using `f64` for `WktNum` in WKT types
 * Add `Copy` impl to `Coord`
 

--- a/src/geo_types_to_wkt.rs
+++ b/src/geo_types_to_wkt.rs
@@ -1,5 +1,10 @@
 use geo_types::CoordNum;
 
+use crate::to_wkt::{
+    write_geometry, write_geometry_collection, write_line, write_linestring,
+    write_multi_linestring, write_multi_point, write_multi_polygon, write_point, write_polygon,
+    write_rect, write_triangle, WriterWrapper,
+};
 use crate::types::{
     Coord, GeometryCollection, LineString, MultiLineString, MultiPoint, MultiPolygon, Point,
     Polygon,
@@ -33,6 +38,11 @@ where
             geo_types::Geometry::Triangle(g) => g.to_wkt(),
         }
     }
+
+    fn write_wkt(&self, writer: impl std::io::Write) -> std::io::Result<()> {
+        let mut writer_wrapper = WriterWrapper::new(writer);
+        write_geometry(&mut writer_wrapper, self).map_err(|err| writer_wrapper.into_io_err(err))
+    }
 }
 
 /// # Examples
@@ -50,6 +60,11 @@ where
 {
     fn to_wkt(&self) -> Wkt<T> {
         Wkt::Point(g_point_to_w_point(self))
+    }
+
+    fn write_wkt(&self, writer: impl std::io::Write) -> std::io::Result<()> {
+        let mut writer_wrapper = WriterWrapper::new(writer);
+        write_point(&mut writer_wrapper, self).map_err(|err| writer_wrapper.into_io_err(err))
     }
 }
 
@@ -69,6 +84,11 @@ where
     fn to_wkt(&self) -> Wkt<T> {
         g_line_to_w_linestring(self).into()
     }
+
+    fn write_wkt(&self, writer: impl std::io::Write) -> std::io::Result<()> {
+        let mut writer_wrapper = WriterWrapper::new(writer);
+        write_line(&mut writer_wrapper, self).map_err(|err| writer_wrapper.into_io_err(err))
+    }
 }
 
 /// # Examples
@@ -86,6 +106,11 @@ where
 {
     fn to_wkt(&self) -> Wkt<T> {
         g_linestring_to_w_linestring(self).into()
+    }
+
+    fn write_wkt(&self, writer: impl std::io::Write) -> std::io::Result<()> {
+        let mut writer_wrapper = WriterWrapper::new(writer);
+        write_linestring(&mut writer_wrapper, self).map_err(|err| writer_wrapper.into_io_err(err))
     }
 }
 
@@ -105,6 +130,11 @@ where
     fn to_wkt(&self) -> Wkt<T> {
         g_polygon_to_w_polygon(self).into()
     }
+
+    fn write_wkt(&self, writer: impl std::io::Write) -> std::io::Result<()> {
+        let mut writer_wrapper = WriterWrapper::new(writer);
+        write_polygon(&mut writer_wrapper, self).map_err(|err| writer_wrapper.into_io_err(err))
+    }
 }
 
 /// # Examples
@@ -122,6 +152,11 @@ where
 {
     fn to_wkt(&self) -> Wkt<T> {
         g_mpoint_to_w_mpoint(self).into()
+    }
+
+    fn write_wkt(&self, writer: impl std::io::Write) -> std::io::Result<()> {
+        let mut writer_wrapper = WriterWrapper::new(writer);
+        write_multi_point(&mut writer_wrapper, self).map_err(|err| writer_wrapper.into_io_err(err))
     }
 }
 
@@ -142,6 +177,12 @@ where
 {
     fn to_wkt(&self) -> Wkt<T> {
         g_mline_to_w_mline(self).into()
+    }
+
+    fn write_wkt(&self, writer: impl std::io::Write) -> std::io::Result<()> {
+        let mut writer_wrapper = WriterWrapper::new(writer);
+        write_multi_linestring(&mut writer_wrapper, self)
+            .map_err(|err| writer_wrapper.into_io_err(err))
     }
 }
 
@@ -165,6 +206,12 @@ where
     fn to_wkt(&self) -> Wkt<T> {
         g_mpolygon_to_w_mpolygon(self).into()
     }
+
+    fn write_wkt(&self, writer: impl std::io::Write) -> std::io::Result<()> {
+        let mut writer_wrapper = WriterWrapper::new(writer);
+        write_multi_polygon(&mut writer_wrapper, self)
+            .map_err(|err| writer_wrapper.into_io_err(err))
+    }
 }
 
 /// # Examples
@@ -185,6 +232,12 @@ where
     fn to_wkt(&self) -> Wkt<T> {
         g_geocol_to_w_geocol(self).into()
     }
+
+    fn write_wkt(&self, writer: impl std::io::Write) -> std::io::Result<()> {
+        let mut writer_wrapper = WriterWrapper::new(writer);
+        write_geometry_collection(&mut writer_wrapper, self)
+            .map_err(|err| writer_wrapper.into_io_err(err))
+    }
 }
 
 /// # Examples
@@ -203,6 +256,11 @@ where
     fn to_wkt(&self) -> Wkt<T> {
         g_rect_to_w_polygon(self).into()
     }
+
+    fn write_wkt(&self, writer: impl std::io::Write) -> std::io::Result<()> {
+        let mut writer_wrapper = WriterWrapper::new(writer);
+        write_rect(&mut writer_wrapper, self).map_err(|err| writer_wrapper.into_io_err(err))
+    }
 }
 
 /// # Examples
@@ -220,6 +278,11 @@ where
 {
     fn to_wkt(&self) -> Wkt<T> {
         g_triangle_to_w_polygon(self).into()
+    }
+
+    fn write_wkt(&self, writer: impl std::io::Write) -> std::io::Result<()> {
+        let mut writer_wrapper = WriterWrapper::new(writer);
+        write_triangle(&mut writer_wrapper, self).map_err(|err| writer_wrapper.into_io_err(err))
     }
 }
 


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
- [x] I ran cargo fmt
---

Closes https://github.com/georust/wkt/issues/93.

There are three methods on the `ToWkt` trait. There's 
```rs
fn to_wkt(&self) -> Wkt<T>;
```
which will always allocate a `Wkt` struct.

This PR overrides the default implementation of
```rs
fn write_wkt(&self, writer: impl io::Write) -> io::Result<()> {
```
so that `write_wkt` does not construct a full `Wkt` struct before writing.

In theory we could also avoid the `Wkt` allocation for
```rs
fn wkt_string(&self) -> String {
```
by reusing the `write_wkt` method from inside of that, but there are a couple problems. 1) `wkt_string` is infallible, while `write_wkt` is fallible. 2) `write_wkt` requires a `std::io::Write`, which `&mut String` doesn't implement, so we'd have to write to a `Vec<u8>` and then parse that back to a `String`.