### PR TITLE
Fix doc build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ on:
 
 name: Run tests
 jobs:
-  wkt:
+  test:
     name: wkt
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
@@ -28,3 +28,13 @@ jobs:
       - run: cargo clippy --all-features --all-targets -- -Dwarnings
       - run: cargo test --all-features
       - run: cargo test --no-default-features
+  doc:
+    name: Documentation
+    runs-on: ubuntu-latest
+    env:
+      RUSTDOCFLAGS: -Dwarnings
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@nightly
+      - uses: dtolnay/install@cargo-docs-rs
+      - run: cargo docs-rs

--- a/src/deserialize/mod.rs
+++ b/src/deserialize/mod.rs
@@ -143,35 +143,6 @@ where
     }
 }
 
-struct GeometryVisitor<T> {
-    _marker: PhantomData<T>,
-}
-
-impl<T> Default for GeometryVisitor<T> {
-    fn default() -> Self {
-        GeometryVisitor {
-            _marker: PhantomData,
-        }
-    }
-}
-
-impl<T> Visitor<'_> for GeometryVisitor<T>
-where
-    T: FromStr + Default + WktNum,
-{
-    type Value = Wkt<T>;
-    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(formatter, "a valid WKT format")
-    }
-    fn visit_str<E>(self, s: &str) -> Result<Self::Value, E>
-    where
-        E: Error,
-    {
-        let wkt = Wkt::from_str(s).map_err(|e| serde::de::Error::custom(e))?;
-        Ok(wkt)
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -184,71 +155,33 @@ mod tests {
         Deserializer, Error as _, IntoDeserializer,
     };
 
-    mod wkt {
-        use super::*;
-
-        #[test]
-        fn deserialize() {
-            let deserializer: StrDeserializer<'_, Error> = "POINT (10 20.1)".into_deserializer();
-            let wkt = deserializer
-                .deserialize_any(WktVisitor::<f64>::default())
-                .unwrap();
-            assert!(matches!(
-                wkt,
-                Wkt::Point(Point {
-                    coord: Some(Coord {
-                        x: _, // floating-point types cannot be used in patterns
-                        y: _, // floating-point types cannot be used in patterns
-                        z: None,
-                        m: None,
-                    }),
-                    dim: _dim,
-                })
-            ));
-        }
-
-        #[test]
-        fn deserialize_error() {
-            let deserializer: StrDeserializer<'_, Error> = "POINT (10 20.1A)".into_deserializer();
-            let wkt = deserializer.deserialize_any(WktVisitor::<f64>::default());
-            assert_eq!(
-                wkt.unwrap_err(),
-                Error::custom("Unable to parse input number as the desired output type")
-            );
-        }
+    #[test]
+    fn deserialize() {
+        let deserializer: StrDeserializer<'_, Error> = "POINT (10 20.1)".into_deserializer();
+        let wkt = deserializer
+            .deserialize_any(WktVisitor::<f64>::default())
+            .unwrap();
+        assert!(matches!(
+            wkt,
+            Wkt::Point(Point {
+                coord: Some(Coord {
+                    x: _, // floating-point types cannot be used in patterns
+                    y: _, // floating-point types cannot be used in patterns
+                    z: None,
+                    m: None,
+                }),
+                dim: _dim,
+            })
+        ));
     }
 
-    mod geometry {
-        use super::*;
-
-        #[test]
-        fn deserialize() {
-            let deserializer: StrDeserializer<'_, Error> = "POINT (42 3.14)".into_deserializer();
-            let geometry = deserializer
-                .deserialize_any(GeometryVisitor::<f64>::default())
-                .unwrap();
-            assert!(matches!(
-                geometry,
-                Wkt::Point(Point {
-                    coord: Some(Coord {
-                        x: _, // floating-point types cannot be used in patterns
-                        y: _, // floating-point types cannot be used in patterns
-                        z: None,
-                        m: None,
-                    }),
-                    dim: _dim,
-                })
-            ));
-        }
-
-        #[test]
-        fn deserialize_error() {
-            let deserializer: StrDeserializer<'_, Error> = "POINT (42 PI3.14)".into_deserializer();
-            let geometry = deserializer.deserialize_any(GeometryVisitor::<f64>::default());
-            assert_eq!(
-                geometry.unwrap_err(),
-                Error::custom("Expected a number for the Y coordinate")
-            );
-        }
+    #[test]
+    fn deserialize_error() {
+        let deserializer: StrDeserializer<'_, Error> = "POINT (10 20.1A)".into_deserializer();
+        let wkt = deserializer.deserialize_any(WktVisitor::<f64>::default());
+        assert_eq!(
+            wkt.unwrap_err(),
+            Error::custom("Unable to parse input number as the desired output type")
+        );
     }
 }

--- a/src/deserialize/mod.rs
+++ b/src/deserialize/mod.rs
@@ -1,8 +1,7 @@
 //! This module deserialises to WKT using [`serde`].
 //!
 //! You can deserialise to [`geo_types`] or any other implementor of [`TryFromWkt`], using
-//! [`deserialize_wkt`]. Or you can store this crates internal primitives [`wkt`]
-//! or [`Wkt`] in your struct fields.
+//! [`deserialize_wkt`]. Alternatively, you can store this crate's [`Wkt`] in your struct fields.
 
 use crate::{TryFromWkt, Wkt, WktNum};
 use serde::de::{Deserializer, Error, Visitor};
@@ -19,7 +18,7 @@ pub mod geo_types;
 /// Deserializes a WKT String into any type which implements `TryFromWkt`.
 ///
 /// This is useful when you have a struct which has a structured geometry field, (like a [`geo`](https://docs.rs/geo) or
-/// [`geo-types`] geometry) stored as WKT.
+/// [`geo-types`](https://docs.rs/geo-types) geometry) stored as WKT.
 ///
 #[cfg_attr(feature = "geo-types", doc = "```")]
 #[cfg_attr(not(feature = "geo-types"), doc = "```ignore")]

--- a/src/infer_type.rs
+++ b/src/infer_type.rs
@@ -106,7 +106,7 @@ pub fn infer_type(input: &str) -> Result<(GeometryType, Dimension), String> {
         } else if input.starts_with(GEOMETRYCOLLECTION) {
             Ok((GeometryType::GeometryCollection, dim))
         } else {
-            return Err(format!("Unsupported WKT prefix {}", input));
+            Err(format!("Unsupported WKT prefix {}", input))
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@
 // The unstable `doc_auto_cfg` feature annotates documentation with any required cfg/features
 // needed for optional items. We set the `docsrs` config when building for docs.rs. To use it
 // in a local docs build, run: `cargo +nightly rustdoc --all-features -- --cfg docsrs`
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 //! The `wkt` crate provides conversions to and from the [WKT (Well Known Text)](https://en.wikipedia.org/wiki/Well-known_text_representation_of_geometry)
 //! geometry format.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@
 //! Conversions are available via the [`TryFromWkt`] and [`ToWkt`] traits, with implementations for
 //! [`geo_types`] and [`geo_traits`] primitives enabled by default.
 //!
-//! For advanced usage, see the [`types`](crate::types) module for a list of internally used types.
+//! For advanced usage, see the [`types`] module for a list of internally used types.
 //!
 //! This crate has optional `serde` integration for deserializing fields containing WKT. See
 //! [`deserialize`] for an example.

--- a/src/to_wkt/mod.rs
+++ b/src/to_wkt/mod.rs
@@ -33,9 +33,9 @@ impl<W: io::Write> WriterWrapper<W> {
             (Error::FmtError(_), Some(io_err)) => io_err,
             (Error::FmtError(fmt_err), None) => {
                 debug_assert!(false, "FmtError without setting an error on WriterWrapper");
-                io::Error::new(io::ErrorKind::Other, fmt_err.to_string())
+                io::Error::other(fmt_err.to_string())
             }
-            (other, _) => io::Error::new(io::ErrorKind::Other, other.to_string()),
+            (other, _) => io::Error::other(other.to_string()),
         }
     }
 }
@@ -108,10 +108,7 @@ mod tests {
         struct FailingWriter;
         impl io::Write for FailingWriter {
             fn write(&mut self, _buf: &[u8]) -> io::Result<usize> {
-                Err(io::Error::new(
-                    io::ErrorKind::Other,
-                    "FailingWriter always fails",
-                ))
+                Err(io::Error::other("FailingWriter always fails"))
             }
 
             fn flush(&mut self) -> io::Result<()> {


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [n/a] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
- [x] I ran cargo fmt
---

Fixes this error:

```
# This is pretty close to how docs.rs builds our docs
$ RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --all-features       
 Documenting thiserror v1.0.69
 Documenting wkt v0.14.0 (/Users/mkirk/src/georust/wkt)
error[E0557]: feature has been removed
  --> src/lib.rs:19:29
   |
19 | #![cfg_attr(docsrs, feature(doc_auto_cfg))]
   |                             ^^^^^^^^^^^^ feature has been removed
   |
   = note: removed in 1.92.0; see <https://github.com/rust-lang/rust/pull/138907> for more information
   = note: merged into `doc_cfg`

error: Compilation failed, aborting rustdoc
```

I've also addressed some warnings while building docs and added a CI job to test the doc build.