### PR TITLE
Bound GeometryCollection nesting depth to prevent stack overflow

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-* Your change here.
+* Bound `GEOMETRYCOLLECTION` nesting depth to prevent stack overflow when parsing untrusted WKT.
 
 ## 0.14.0 - 2025-05-08
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,6 +162,9 @@ impl<T> WktNum for T where T: Num + NumCast + PartialOrd + PartialEq + Copy + fm
 pub trait WktFloat: WktNum + Float {}
 impl<T> WktFloat for T where T: WktNum + Float {}
 
+/// Maximum GeometryCollection nesting depth to prevent stack overflow.
+const MAX_DEPTH: usize = 128;
+
 #[derive(Clone, Debug, PartialEq)]
 /// All supported WKT geometry [`types`]
 pub enum Wkt<T: WktNum = f64> {
@@ -199,6 +202,7 @@ where
     fn from_word_and_tokens(
         word: &str,
         tokens: &mut PeekableTokens<T>,
+        depth: usize,
     ) -> Result<Self, &'static str> {
         // Normally Z/M/ZM is separated by a space from the primary WKT word. E.g. `POINT Z`
         // instead of `POINTZ`. However we wish to support both types (in reading). When written
@@ -206,13 +210,14 @@ where
         // matches here.
         match word {
             w if w.eq_ignore_ascii_case("POINT") => {
-                let x = <Point<T> as FromTokens<T>>::from_tokens_with_header(tokens, None);
+                let x = <Point<T> as FromTokens<T>>::from_tokens_with_header(tokens, None, depth);
                 x.map(|y| y.into())
             }
             w if w.eq_ignore_ascii_case("POINTZ") => {
                 let x = <Point<T> as FromTokens<T>>::from_tokens_with_header(
                     tokens,
                     Some(Dimension::XYZ),
+                    depth,
                 );
                 x.map(|y| y.into())
             }
@@ -220,6 +225,7 @@ where
                 let x = <Point<T> as FromTokens<T>>::from_tokens_with_header(
                     tokens,
                     Some(Dimension::XYM),
+                    depth,
                 );
                 x.map(|y| y.into())
             }
@@ -227,17 +233,20 @@ where
                 let x = <Point<T> as FromTokens<T>>::from_tokens_with_header(
                     tokens,
                     Some(Dimension::XYZM),
+                    depth,
                 );
                 x.map(|y| y.into())
             }
             w if w.eq_ignore_ascii_case("LINESTRING") || w.eq_ignore_ascii_case("LINEARRING") => {
-                let x = <LineString<T> as FromTokens<T>>::from_tokens_with_header(tokens, None);
+                let x =
+                    <LineString<T> as FromTokens<T>>::from_tokens_with_header(tokens, None, depth);
                 x.map(|y| y.into())
             }
             w if w.eq_ignore_ascii_case("LINESTRINGZ") => {
                 let x = <LineString<T> as FromTokens<T>>::from_tokens_with_header(
                     tokens,
                     Some(Dimension::XYZ),
+                    depth,
                 );
                 x.map(|y| y.into())
             }
@@ -245,6 +254,7 @@ where
                 let x = <LineString<T> as FromTokens<T>>::from_tokens_with_header(
                     tokens,
                     Some(Dimension::XYM),
+                    depth,
                 );
                 x.map(|y| y.into())
             }
@@ -252,17 +262,19 @@ where
                 let x = <LineString<T> as FromTokens<T>>::from_tokens_with_header(
                     tokens,
                     Some(Dimension::XYZM),
+                    depth,
                 );
                 x.map(|y| y.into())
             }
             w if w.eq_ignore_ascii_case("POLYGON") => {
-                let x = <Polygon<T> as FromTokens<T>>::from_tokens_with_header(tokens, None);
+                let x = <Polygon<T> as FromTokens<T>>::from_tokens_with_header(tokens, None, depth);
                 x.map(|y| y.into())
             }
             w if w.eq_ignore_ascii_case("POLYGONZ") => {
                 let x = <Polygon<T> as FromTokens<T>>::from_tokens_with_header(
                     tokens,
                     Some(Dimension::XYZ),
+                    depth,
                 );
                 x.map(|y| y.into())
             }
@@ -270,6 +282,7 @@ where
                 let x = <Polygon<T> as FromTokens<T>>::from_tokens_with_header(
                     tokens,
                     Some(Dimension::XYM),
+                    depth,
                 );
                 x.map(|y| y.into())
             }
@@ -277,17 +290,20 @@ where
                 let x = <Polygon<T> as FromTokens<T>>::from_tokens_with_header(
                     tokens,
                     Some(Dimension::XYZM),
+                    depth,
                 );
                 x.map(|y| y.into())
             }
             w if w.eq_ignore_ascii_case("MULTIPOINT") => {
-                let x = <MultiPoint<T> as FromTokens<T>>::from_tokens_with_header(tokens, None);
+                let x =
+                    <MultiPoint<T> as FromTokens<T>>::from_tokens_with_header(tokens, None, depth);
                 x.map(|y| y.into())
             }
             w if w.eq_ignore_ascii_case("MULTIPOINTZ") => {
                 let x = <MultiPoint<T> as FromTokens<T>>::from_tokens_with_header(
                     tokens,
                     Some(Dimension::XYZ),
+                    depth,
                 );
                 x.map(|y| y.into())
             }
@@ -295,6 +311,7 @@ where
                 let x = <MultiPoint<T> as FromTokens<T>>::from_tokens_with_header(
                     tokens,
                     Some(Dimension::XYM),
+                    depth,
                 );
                 x.map(|y| y.into())
             }
@@ -302,18 +319,21 @@ where
                 let x = <MultiPoint<T> as FromTokens<T>>::from_tokens_with_header(
                     tokens,
                     Some(Dimension::XYZM),
+                    depth,
                 );
                 x.map(|y| y.into())
             }
             w if w.eq_ignore_ascii_case("MULTILINESTRING") => {
-                let x =
-                    <MultiLineString<T> as FromTokens<T>>::from_tokens_with_header(tokens, None);
+                let x = <MultiLineString<T> as FromTokens<T>>::from_tokens_with_header(
+                    tokens, None, depth,
+                );
                 x.map(|y| y.into())
             }
             w if w.eq_ignore_ascii_case("MULTILINESTRINGZ") => {
                 let x = <MultiLineString<T> as FromTokens<T>>::from_tokens_with_header(
                     tokens,
                     Some(Dimension::XYZ),
+                    depth,
                 );
                 x.map(|y| y.into())
             }
@@ -321,6 +341,7 @@ where
                 let x = <MultiLineString<T> as FromTokens<T>>::from_tokens_with_header(
                     tokens,
                     Some(Dimension::XYM),
+                    depth,
                 );
                 x.map(|y| y.into())
             }
@@ -328,17 +349,21 @@ where
                 let x = <MultiLineString<T> as FromTokens<T>>::from_tokens_with_header(
                     tokens,
                     Some(Dimension::XYZM),
+                    depth,
                 );
                 x.map(|y| y.into())
             }
             w if w.eq_ignore_ascii_case("MULTIPOLYGON") => {
-                let x = <MultiPolygon<T> as FromTokens<T>>::from_tokens_with_header(tokens, None);
+                let x = <MultiPolygon<T> as FromTokens<T>>::from_tokens_with_header(
+                    tokens, None, depth,
+                );
                 x.map(|y| y.into())
             }
             w if w.eq_ignore_ascii_case("MULTIPOLYGONZ") => {
                 let x = <MultiPolygon<T> as FromTokens<T>>::from_tokens_with_header(
                     tokens,
                     Some(Dimension::XYZ),
+                    depth,
                 );
                 x.map(|y| y.into())
             }
@@ -346,6 +371,7 @@ where
                 let x = <MultiPolygon<T> as FromTokens<T>>::from_tokens_with_header(
                     tokens,
                     Some(Dimension::XYM),
+                    depth,
                 );
                 x.map(|y| y.into())
             }
@@ -353,32 +379,29 @@ where
                 let x = <MultiPolygon<T> as FromTokens<T>>::from_tokens_with_header(
                     tokens,
                     Some(Dimension::XYZM),
+                    depth,
                 );
                 x.map(|y| y.into())
             }
-            w if w.eq_ignore_ascii_case("GEOMETRYCOLLECTION") => {
-                let x =
-                    <GeometryCollection<T> as FromTokens<T>>::from_tokens_with_header(tokens, None);
-                x.map(|y| y.into())
-            }
-            w if w.eq_ignore_ascii_case("GEOMETRYCOLLECTIONZ") => {
+            w if w.eq_ignore_ascii_case("GEOMETRYCOLLECTION")
+                || w.eq_ignore_ascii_case("GEOMETRYCOLLECTIONZ")
+                || w.eq_ignore_ascii_case("GEOMETRYCOLLECTIONM")
+                || w.eq_ignore_ascii_case("GEOMETRYCOLLECTIONZM") =>
+            {
+                if depth >= MAX_DEPTH {
+                    return Err("Maximum GeometryCollection nesting depth exceeded");
+                }
+                let dim = if w.eq_ignore_ascii_case("GEOMETRYCOLLECTIONZ") {
+                    Some(Dimension::XYZ)
+                } else if w.eq_ignore_ascii_case("GEOMETRYCOLLECTIONM") {
+                    Some(Dimension::XYM)
+                } else if w.eq_ignore_ascii_case("GEOMETRYCOLLECTIONZM") {
+                    Some(Dimension::XYZM)
+                } else {
+                    None
+                };
                 let x = <GeometryCollection<T> as FromTokens<T>>::from_tokens_with_header(
-                    tokens,
-                    Some(Dimension::XYZ),
-                );
-                x.map(|y| y.into())
-            }
-            w if w.eq_ignore_ascii_case("GEOMETRYCOLLECTIONM") => {
-                let x = <GeometryCollection<T> as FromTokens<T>>::from_tokens_with_header(
-                    tokens,
-                    Some(Dimension::XYM),
-                );
-                x.map(|y| y.into())
-            }
-            w if w.eq_ignore_ascii_case("GEOMETRYCOLLECTIONZM") => {
-                let x = <GeometryCollection<T> as FromTokens<T>>::from_tokens_with_header(
-                    tokens,
-                    Some(Dimension::XYZM),
+                    tokens, dim, depth,
                 );
                 x.map(|y| y.into())
             }
@@ -411,7 +434,7 @@ where
             }
             _ => return Err("Invalid WKT format"),
         };
-        Wkt::from_word_and_tokens(&word, &mut tokens)
+        Wkt::from_word_and_tokens(&word, &mut tokens, 0)
     }
 }
 
@@ -771,7 +794,11 @@ trait FromTokens<T>: Sized + Default
 where
     T: WktNum + FromStr + Default,
 {
-    fn from_tokens(tokens: &mut PeekableTokens<T>, dim: Dimension) -> Result<Self, &'static str>;
+    fn from_tokens(
+        tokens: &mut PeekableTokens<T>,
+        dim: Dimension,
+        depth: usize,
+    ) -> Result<Self, &'static str>;
 
     fn new_empty(dim: Dimension) -> Self;
 
@@ -780,41 +807,44 @@ where
     fn from_tokens_with_header(
         tokens: &mut PeekableTokens<T>,
         dim: Option<Dimension>,
+        depth: usize,
     ) -> Result<Self, &'static str> {
         let dim = if let Some(dim) = dim {
             dim
         } else {
             infer_geom_dimension(tokens)?
         };
-        FromTokens::from_tokens_with_parens(tokens, dim)
+        FromTokens::from_tokens_with_parens(tokens, dim, depth)
     }
 
     fn from_tokens_with_parens(
         tokens: &mut PeekableTokens<T>,
         dim: Dimension,
+        depth: usize,
     ) -> Result<Self, &'static str> {
         match tokens.next().transpose()? {
             Some(Token::ParenOpen) => (),
-            Some(Token::Word(ref s)) if s.eq_ignore_ascii_case("EMPTY") => {
+            Some(Token::Word(s)) if s.eq_ignore_ascii_case("EMPTY") => {
                 return Ok(Self::new_empty(dim));
             }
             _ => return Err("Missing open parenthesis for type"),
         };
-        let result = FromTokens::from_tokens(tokens, dim);
+        let result = FromTokens::from_tokens(tokens, dim, depth)?;
         match tokens.next().transpose()? {
             Some(Token::ParenClose) => (),
             _ => return Err("Missing closing parenthesis for type"),
         };
-        result
+        Ok(result)
     }
 
     fn from_tokens_with_optional_parens(
         tokens: &mut PeekableTokens<T>,
         dim: Dimension,
+        depth: usize,
     ) -> Result<Self, &'static str> {
         match tokens.peek() {
-            Some(Ok(Token::ParenOpen)) => Self::from_tokens_with_parens(tokens, dim),
-            _ => Self::from_tokens(tokens, dim),
+            Some(Ok(Token::ParenOpen)) => Self::from_tokens_with_parens(tokens, dim, depth),
+            _ => Self::from_tokens(tokens, dim, depth),
         }
     }
 
@@ -822,19 +852,20 @@ where
         f: F,
         tokens: &mut PeekableTokens<T>,
         dim: Dimension,
+        depth: usize,
     ) -> Result<Vec<Self>, &'static str>
     where
-        F: Fn(&mut PeekableTokens<T>, Dimension) -> Result<Self, &'static str>,
+        F: Fn(&mut PeekableTokens<T>, Dimension, usize) -> Result<Self, &'static str>,
     {
         let mut items = Vec::new();
 
-        let item = f(tokens, dim)?;
+        let item = f(tokens, dim, depth)?;
         items.push(item);
 
         while let Some(&Ok(Token::Comma)) = tokens.peek() {
             tokens.next(); // throw away comma
 
-            let item = f(tokens, dim)?;
+            let item = f(tokens, dim, depth)?;
             items.push(item);
         }
 

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -87,7 +87,7 @@ where
                     Err(_) => {
                         log::warn!(
                             "Failed to parse input: '{}' as {}",
-                            &number,
+                            number,
                             type_name::<T>()
                         );
                         return Some(Err(

--- a/src/types/coord.rs
+++ b/src/types/coord.rs
@@ -44,7 +44,11 @@ impl<T> FromTokens<T> for Coord<T>
 where
     T: WktNum + FromStr + Default,
 {
-    fn from_tokens(tokens: &mut PeekableTokens<T>, dim: Dimension) -> Result<Self, &'static str> {
+    fn from_tokens(
+        tokens: &mut PeekableTokens<T>,
+        dim: Dimension,
+        _depth: usize,
+    ) -> Result<Self, &'static str> {
         let x = match tokens.next().transpose()? {
             Some(Token::Number(n)) => n,
             _ => return Err("Expected a number for the X coordinate"),

--- a/src/types/geometrycollection.rs
+++ b/src/types/geometrycollection.rs
@@ -98,7 +98,11 @@ impl<T> FromTokens<T> for GeometryCollection<T>
 where
     T: WktNum + FromStr + Default,
 {
-    fn from_tokens(tokens: &mut PeekableTokens<T>, dim: Dimension) -> Result<Self, &'static str> {
+    fn from_tokens(
+        tokens: &mut PeekableTokens<T>,
+        dim: Dimension,
+        depth: usize,
+    ) -> Result<Self, &'static str> {
         let mut items = Vec::new();
 
         let word = match tokens.next().transpose()? {
@@ -106,7 +110,7 @@ where
             _ => return Err("Expected a word in GEOMETRYCOLLECTION"),
         };
 
-        let item = Wkt::from_word_and_tokens(&word, tokens)?;
+        let item = Wkt::from_word_and_tokens(&word, tokens, depth + 1)?;
         items.push(item);
 
         while let Some(&Ok(Token::Comma)) = tokens.peek() {
@@ -117,7 +121,7 @@ where
                 _ => return Err("Expected a word in GEOMETRYCOLLECTION"),
             };
 
-            let item = Wkt::from_word_and_tokens(&word, tokens)?;
+            let item = Wkt::from_word_and_tokens(&word, tokens, depth + 1)?;
             items.push(item);
         }
 
@@ -455,5 +459,167 @@ mod tests {
              )",
             format!("{}", geometrycollection)
         );
+    }
+    #[test]
+    fn deeply_nested_geometrycollection_returns_error() {
+        // Prevents stack overflow on deeply nested GeometryCollections
+        let handle = std::thread::Builder::new()
+            .stack_size(1_048_576)
+            .spawn(|| {
+                let depth = 200;
+                let mut s = String::new();
+                for _ in 0..depth {
+                    s.push_str("GEOMETRYCOLLECTION(");
+                }
+                s.push_str("POINT(1 2)");
+                for _ in 0..depth {
+                    s.push(')');
+                }
+                let result = Wkt::<f64>::from_str(&s);
+                assert!(
+                    result.is_err(),
+                    "Parsing deeply nested GeometryCollection should return an error"
+                );
+            })
+            .expect("Failed to spawn thread");
+
+        let join_result = handle.join();
+        assert!(
+            join_result.is_ok(),
+            "Parser thread should not panic or overflow the stack"
+        );
+    }
+    #[test]
+    fn nested_geometrycollection_parses() {
+        let wkt: Wkt<f64> =
+            Wkt::from_str("GEOMETRYCOLLECTION(GEOMETRYCOLLECTION(POINT(1 2)),LINESTRING(0 0,1 1))")
+                .unwrap();
+        let outer = match wkt {
+            Wkt::GeometryCollection(gc) => gc,
+            _ => unreachable!(),
+        };
+        assert_eq!(outer.geoms.len(), 2);
+
+        let inner = match &outer.geoms[0] {
+            Wkt::GeometryCollection(gc) => gc,
+            _ => unreachable!(),
+        };
+        assert_eq!(inner.geoms.len(), 1);
+    }
+
+    #[test]
+    fn geometrycollection_depth_boundary() {
+        use crate::MAX_DEPTH;
+
+        // MAX_DEPTH levels parse successfully
+        let mut s = String::new();
+        for _ in 0..MAX_DEPTH {
+            s.push_str("GEOMETRYCOLLECTION(");
+        }
+        s.push_str("POINT(0 0)");
+        for _ in 0..MAX_DEPTH {
+            s.push(')');
+        }
+        assert!(
+            Wkt::<f64>::from_str(&s).is_ok(),
+            "Depth {} (MAX_DEPTH) should parse",
+            MAX_DEPTH
+        );
+
+        // MAX_DEPTH + 1 levels exceed the limit
+        let mut s = String::new();
+        for _ in 0..=MAX_DEPTH {
+            s.push_str("GEOMETRYCOLLECTION(");
+        }
+        s.push_str("POINT(0 0)");
+        for _ in 0..=MAX_DEPTH {
+            s.push(')');
+        }
+        let result = Wkt::<f64>::from_str(&s);
+        assert!(
+            result.is_err(),
+            "Depth {} (MAX_DEPTH + 1) should fail",
+            MAX_DEPTH + 1
+        );
+        assert_eq!(
+            result.unwrap_err(),
+            "Maximum GeometryCollection nesting depth exceeded"
+        );
+    }
+
+    #[test]
+    fn geometrycollection_sibling_nesting_counts_independently() {
+        // Sibling GeometryCollections share depth
+        let wkt: Wkt<f64> = Wkt::from_str(
+            "GEOMETRYCOLLECTION(GEOMETRYCOLLECTION(POINT(0 0)),GEOMETRYCOLLECTION(POINT(1 1)))",
+        )
+        .unwrap();
+        let outer = match wkt {
+            Wkt::GeometryCollection(gc) => gc,
+            _ => unreachable!(),
+        };
+        assert_eq!(outer.geoms.len(), 2);
+    }
+
+    #[test]
+    fn geometrycollection_z_depth_limit() {
+        let handle = std::thread::Builder::new()
+            .stack_size(1_048_576)
+            .spawn(|| {
+                let depth = 200;
+                let mut s = String::new();
+                for _ in 0..depth {
+                    s.push_str("GEOMETRYCOLLECTION Z(");
+                }
+                s.push_str("POINT Z(1 2 3)");
+                for _ in 0..depth {
+                    s.push(')');
+                }
+                Wkt::<f64>::from_str(&s)
+            })
+            .expect("Failed to spawn thread")
+            .join();
+
+        let result = handle.expect("Thread should not overflow");
+        assert!(result.is_err());
+    }
+    #[test]
+    fn geometrycollection_m_and_zm_depth_limit() {
+        for variant in ["GEOMETRYCOLLECTION M", "GEOMETRYCOLLECTION ZM"] {
+            let mut s = String::new();
+            for _ in 0..200 {
+                s.push_str(&format!("{}(", variant));
+            }
+            if variant.ends_with("M") && !variant.ends_with("ZM") {
+                s.push_str("POINT M(1 2 3)");
+            } else {
+                s.push_str("POINT ZM(1 2 3 4)");
+            }
+            for _ in 0..200 {
+                s.push(')');
+            }
+            let result = Wkt::<f64>::from_str(&s);
+            assert!(result.is_err(), "{} deeply nested should fail", variant);
+        }
+    }
+
+    #[test]
+    fn geometrycollection_wide_nesting() {
+        // Breadth does not affect depth counting
+        let mut s = "GEOMETRYCOLLECTION(".to_string();
+        for i in 0..50 {
+            if i > 0 {
+                s.push(',');
+            }
+            s.push_str("GEOMETRYCOLLECTION(POINT(1 2))");
+        }
+        s.push(')');
+
+        let wkt: Wkt<f64> = Wkt::from_str(&s).unwrap();
+        let outer = match wkt {
+            Wkt::GeometryCollection(gc) => gc,
+            _ => unreachable!(),
+        };
+        assert_eq!(outer.geoms.len(), 50);
     }
 }

--- a/src/types/linestring.rs
+++ b/src/types/linestring.rs
@@ -88,8 +88,13 @@ impl<T> FromTokens<T> for LineString<T>
 where
     T: WktNum + FromStr + Default,
 {
-    fn from_tokens(tokens: &mut PeekableTokens<T>, dim: Dimension) -> Result<Self, &'static str> {
-        let result = FromTokens::comma_many(<Coord<T> as FromTokens<T>>::from_tokens, tokens, dim);
+    fn from_tokens(
+        tokens: &mut PeekableTokens<T>,
+        dim: Dimension,
+        depth: usize,
+    ) -> Result<Self, &'static str> {
+        let result =
+            FromTokens::comma_many(<Coord<T> as FromTokens<T>>::from_tokens, tokens, dim, depth);
         result.map(|coords| LineString { coords, dim })
     }
 

--- a/src/types/multilinestring.rs
+++ b/src/types/multilinestring.rs
@@ -99,11 +99,16 @@ impl<T> FromTokens<T> for MultiLineString<T>
 where
     T: WktNum + FromStr + Default,
 {
-    fn from_tokens(tokens: &mut PeekableTokens<T>, dim: Dimension) -> Result<Self, &'static str> {
+    fn from_tokens(
+        tokens: &mut PeekableTokens<T>,
+        dim: Dimension,
+        depth: usize,
+    ) -> Result<Self, &'static str> {
         let result = FromTokens::comma_many(
             <LineString<T> as FromTokens<T>>::from_tokens_with_parens,
             tokens,
             dim,
+            depth,
         );
         result.map(|line_strings| MultiLineString { line_strings, dim })
     }

--- a/src/types/multipoint.rs
+++ b/src/types/multipoint.rs
@@ -97,11 +97,16 @@ impl<T> FromTokens<T> for MultiPoint<T>
 where
     T: WktNum + FromStr + Default,
 {
-    fn from_tokens(tokens: &mut PeekableTokens<T>, dim: Dimension) -> Result<Self, &'static str> {
+    fn from_tokens(
+        tokens: &mut PeekableTokens<T>,
+        dim: Dimension,
+        depth: usize,
+    ) -> Result<Self, &'static str> {
         let result = FromTokens::comma_many(
             <Point<T> as FromTokens<T>>::from_tokens_with_optional_parens,
             tokens,
             dim,
+            depth,
         );
         result.map(|points| MultiPoint { points, dim })
     }

--- a/src/types/multipolygon.rs
+++ b/src/types/multipolygon.rs
@@ -97,11 +97,16 @@ impl<T> FromTokens<T> for MultiPolygon<T>
 where
     T: WktNum + FromStr + Default,
 {
-    fn from_tokens(tokens: &mut PeekableTokens<T>, dim: Dimension) -> Result<Self, &'static str> {
+    fn from_tokens(
+        tokens: &mut PeekableTokens<T>,
+        dim: Dimension,
+        depth: usize,
+    ) -> Result<Self, &'static str> {
         let result = FromTokens::comma_many(
             <Polygon<T> as FromTokens<T>>::from_tokens_with_parens,
             tokens,
             dim,
+            depth,
         );
         result.map(|polygons| MultiPolygon { polygons, dim })
     }

--- a/src/types/point.rs
+++ b/src/types/point.rs
@@ -88,8 +88,12 @@ impl<T> FromTokens<T> for Point<T>
 where
     T: WktNum + FromStr + Default,
 {
-    fn from_tokens(tokens: &mut PeekableTokens<T>, dim: Dimension) -> Result<Self, &'static str> {
-        let result = <Coord<T> as FromTokens<T>>::from_tokens(tokens, dim);
+    fn from_tokens(
+        tokens: &mut PeekableTokens<T>,
+        dim: Dimension,
+        _depth: usize,
+    ) -> Result<Self, &'static str> {
+        let result = <Coord<T> as FromTokens<T>>::from_tokens(tokens, dim, _depth);
         result.map(|coord| Point {
             coord: Some(coord),
             dim,

--- a/src/types/polygon.rs
+++ b/src/types/polygon.rs
@@ -98,11 +98,16 @@ impl<T> FromTokens<T> for Polygon<T>
 where
     T: WktNum + FromStr + Default,
 {
-    fn from_tokens(tokens: &mut PeekableTokens<T>, dim: Dimension) -> Result<Self, &'static str> {
+    fn from_tokens(
+        tokens: &mut PeekableTokens<T>,
+        dim: Dimension,
+        depth: usize,
+    ) -> Result<Self, &'static str> {
         let result = FromTokens::comma_many(
             <LineString<T> as FromTokens<T>>::from_tokens_with_parens,
             tokens,
             dim,
+            depth,
         );
         result.map(|rings| Polygon { rings, dim })
     }


### PR DESCRIPTION
Deeply nested `GEOMETRYCOLLECTION` WKT caused stack overflow via unbounded recursion.

Bounds nesting at `MAX_DEPTH` (128) and returns a parse error. Also fixes `from_tokens_with_parens` masking inner parse errors.